### PR TITLE
Sync interfaces for two-way communication to docker repo

### DIFF
--- a/functions/src/api/triggerWorkflow.ts
+++ b/functions/src/api/triggerWorkflow.ts
@@ -17,8 +17,10 @@ export const triggerWorkflow = functions.https.onRequest(
       //   repo: 'docker',
       //   event_type: 'new_base_image_requested',
       //   client_payload: {
-      //     patchTag: '0.1.0',
-      //     minorTag: '0.1',
+      //     jobId: 'someJobId',
+      //     buildId: 'someBuildId',
+      //     patchTag: '0.2.0',
+      //     minorTag: '0.2',
       //     majorTag: '0',
       //   },
       // });
@@ -29,8 +31,10 @@ export const triggerWorkflow = functions.https.onRequest(
       //   repo: 'docker',
       //   event_type: 'new_hub_image_requested',
       //   client_payload: {
-      //     patchTag: '0.1.0',
-      //     minorTag: '0.1',
+      //     jobId: 'someJobId',
+      //     buildId: 'someBuildId',
+      //     patchTag: '0.2.0',
+      //     minorTag: '0.2',
       //     majorTag: '0',
       //   },
       // });
@@ -41,10 +45,12 @@ export const triggerWorkflow = functions.https.onRequest(
       //   repo: 'docker',
       //   event_type: 'new_editor_image_requested',
       //   client_payload: {
+      //     jobId: 'someJobId',
+      //     buildId: 'someBuildId',
       //     unityVersion: '2019.3.11f1',
       //     changeSet: 'ceef2d848e70',
-      //     patchTag: '0.1.0',
-      //     minorTag: '0.1',
+      //     patchTag: '0.2.0',
+      //     minorTag: '0.2',
       //     majorTag: '0',
       //   },
       // });

--- a/functions/src/api/triggerWorkflow.ts
+++ b/functions/src/api/triggerWorkflow.ts
@@ -6,19 +6,50 @@ import { GitHub } from '../config/github';
 export const triggerWorkflow = functions.https.onRequest(
   async (request: Request, response: Response) => {
     try {
+      // @ts-ignore
       const gitHub = await GitHub.init();
 
       // This works only in the "installation" auth scope.
-      const result = await gitHub.repos.createDispatchEvent({
-        owner: 'unity-ci',
-        repo: 'docker',
-        event_type: 'new_build_requested',
-        client_payload: {
-          test_var: 'test value',
-        },
-      });
 
-      response.status(200).send(result);
+      // // Base - SUCCESS
+      // const result = await gitHub.repos.createDispatchEvent({
+      //   owner: 'unity-ci',
+      //   repo: 'docker',
+      //   event_type: 'new_base_image_requested',
+      //   client_payload: {
+      //     patchTag: '0.1.0',
+      //     minorTag: '0.1',
+      //     majorTag: '0',
+      //   },
+      // });
+
+      // // Hub - SUCCESS
+      // const result = await gitHub.repos.createDispatchEvent({
+      //   owner: 'unity-ci',
+      //   repo: 'docker',
+      //   event_type: 'new_hub_image_requested',
+      //   client_payload: {
+      //     patchTag: '0.1.0',
+      //     minorTag: '0.1',
+      //     majorTag: '0',
+      //   },
+      // });
+
+      // // Editor - SUCCESS
+      // const result = await gitHub.repos.createDispatchEvent({
+      //   owner: 'unity-ci',
+      //   repo: 'docker',
+      //   event_type: 'new_editor_image_requested',
+      //   client_payload: {
+      //     unityVersion: '2019.3.11f1',
+      //     changeSet: 'ceef2d848e70',
+      //     patchTag: '0.1.0',
+      //     minorTag: '0.1',
+      //     majorTag: '0',
+      //   },
+      // });
+
+      response.status(200).send(':)');
     } catch (err) {
       firebase.logger.error(err);
       response.status(500).send('Oops.');

--- a/functions/src/model/ciJobs.ts
+++ b/functions/src/model/ciJobs.ts
@@ -29,6 +29,9 @@ export interface CiJob {
   modifiedDate: Timestamp;
 }
 
+/**
+ * A CI job is a high level job, that schedules builds on a [repoVersion-unityVersion] level
+ */
 export class CiJobs {
   static getAll = async (): Promise<CiJob[]> => {
     const snapshot = await db.collection(COLLECTION).get();


### PR DESCRIPTION
#### Changes

- Adds two way communication between versioning backend and unity-ci/docker repo actions.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
