### PR TITLE
populate reporting endpoints

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,6 +1,24 @@
 {
   "indexes": [
     {
+      "collectionGroup": "repoVersions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "major",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "minor",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "patch",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "unityVersions",
       "queryScope": "COLLECTION",
       "fields": [

--- a/functions/src/api/reportBuildFailure.ts
+++ b/functions/src/api/reportBuildFailure.ts
@@ -8,8 +8,8 @@ import { Discord } from '../config/discord';
 
 export const reportBuildFailure = functions.https.onRequest(async (req: Request, res: Response) => {
   try {
-    if (!Token.isValid(req.header('Authorisation'))) {
-      firebase.logger.warn('unauthorised request', req);
+    if (!Token.isValid(req.header('authorization'))) {
+      firebase.logger.warn('unauthorised request', req.headers);
       res.status(403).send('Unauthorized');
       return;
     }

--- a/functions/src/api/reportBuildFailure.ts
+++ b/functions/src/api/reportBuildFailure.ts
@@ -31,7 +31,5 @@ export const reportBuildFailure = functions.https.onRequest(async (req: Request,
     firebase.logger.error(message);
     await Discord.sendAlert(message);
     res.status(500).send('Something went wrong');
-  } finally {
-    await Discord.disconnect();
   }
 });

--- a/functions/src/api/reportBuildFailure.ts
+++ b/functions/src/api/reportBuildFailure.ts
@@ -2,15 +2,36 @@ import { firebase, functions } from '../config/firebase';
 import { Request } from 'firebase-functions/lib/providers/https';
 import { Response } from 'express-serve-static-core';
 import { Token } from '../config/token';
+import { BuildFailure, CiBuilds } from '../model/ciBuilds';
+import { CiJobs } from '../model/ciJobs';
+import { Discord } from '../config/discord';
 
 export const reportBuildFailure = functions.https.onRequest(async (req: Request, res: Response) => {
-  if (!Token.isValid(req.header('Authorisation'))) {
-    firebase.logger.warn('unauthorised request', req);
-    res.status(403).send('Unauthorized');
-    return;
+  try {
+    if (!Token.isValid(req.header('Authorisation'))) {
+      firebase.logger.warn('unauthorised request', req);
+      res.status(403).send('Unauthorized');
+      return;
+    }
+
+    const { body } = req;
+    const { jobId, buildId, reason } = body;
+    const failure: BuildFailure = { reason };
+
+    await CiJobs.markFailureForJob(jobId);
+    await CiBuilds.markBuildAsFailed(buildId, failure);
+
+    firebase.logger.info('Build failure reported.', body);
+    res.status(200).send('OK');
+  } catch (err) {
+    const message = `
+      Something went wrong while wrong while reporting a build failure
+      ${err.message} (${err.status})\n${err.stackTrace}
+    `;
+    firebase.logger.error(message);
+    await Discord.sendAlert(message);
+    res.status(500).send('Something went wrong');
+  } finally {
+    await Discord.disconnect();
   }
-
-  firebase.logger.info('Build failure reported.', req);
-
-  res.status(200).send('OK');
 });

--- a/functions/src/api/reportNewBuild.ts
+++ b/functions/src/api/reportNewBuild.ts
@@ -2,15 +2,41 @@ import { firebase, functions } from '../config/firebase';
 import { Request } from 'firebase-functions/lib/providers/https';
 import { Response } from 'express-serve-static-core';
 import { Token } from '../config/token';
+import { BuildInfo, CiBuilds } from '../model/ciBuilds';
+import { CiJobs } from '../model/ciJobs';
+import { Discord } from '../config/discord';
 
 export const reportNewBuild = functions.https.onRequest(async (req: Request, res: Response) => {
-  if (!Token.isValid(req.header('Authorisation'))) {
-    firebase.logger.warn('unauthorised request', req);
-    res.status(403).send('Unauthorized');
-    return;
+  try {
+    if (!Token.isValid(req.header('Authorisation'))) {
+      firebase.logger.warn('unauthorised request', req);
+      res.status(403).send('Unauthorized');
+      return;
+    }
+
+    const { body } = req;
+    const { buildId, jobId, imageType, baseOs, repoVersion, unityVersion, targetPlatform } = body;
+    const buildInfo: BuildInfo = {
+      baseOs,
+      repoVersion,
+      unityVersion,
+      targetPlatform,
+    };
+
+    await CiJobs.markJobAsInProgress(jobId);
+    await CiBuilds.registerNewBuild(buildId, jobId, imageType, buildInfo);
+
+    firebase.logger.info('new build reported', body);
+    res.status(200).send('OK');
+  } catch (err) {
+    const message = `
+      Something went wrong while wrong while reporting a new build.
+      ${err.message} (${err.status})\n${err.stackTrace}
+    `;
+    firebase.logger.error(message);
+    await Discord.sendAlert(message);
+    res.status(500).send('Something went wrong');
+  } finally {
+    await Discord.disconnect();
   }
-
-  firebase.logger.info('new build reported', req);
-
-  res.status(200).send('OK');
 });

--- a/functions/src/api/reportNewBuild.ts
+++ b/functions/src/api/reportNewBuild.ts
@@ -42,8 +42,6 @@ export const reportNewBuild = functions.https.onRequest(async (req: Request, res
     firebase.logger.error(message);
     await Discord.sendAlert(message);
     res.status(500).send('Something went wrong');
-  } finally {
-    await Discord.disconnect();
   }
 });
 

--- a/functions/src/api/reportPublication.ts
+++ b/functions/src/api/reportPublication.ts
@@ -38,7 +38,5 @@ export const reportPublication = functions.https.onRequest(async (req: Request, 
     firebase.logger.error(message);
     await Discord.sendAlert(message);
     res.status(500).send('Something went wrong');
-  } finally {
-    await Discord.disconnect();
   }
 });

--- a/functions/src/api/reportPublication.ts
+++ b/functions/src/api/reportPublication.ts
@@ -2,15 +2,43 @@ import { firebase, functions } from '../config/firebase';
 import { Request } from 'firebase-functions/lib/providers/https';
 import { Response } from 'express-serve-static-core';
 import { Token } from '../config/token';
+import { CiBuilds, DockerInfo } from '../model/ciBuilds';
+import { CiJobs } from '../model/ciJobs';
+import { Discord } from '../config/discord';
 
 export const reportPublication = functions.https.onRequest(async (req: Request, res: Response) => {
-  if (!Token.isValid(req.header('Authorisation'))) {
-    firebase.logger.warn('unauthorised request', req);
-    res.status(403).send('Unauthorized');
-    return;
+  try {
+    if (!Token.isValid(req.header('Authorisation'))) {
+      firebase.logger.warn('unauthorised request', req);
+      res.status(403).send('Unauthorized');
+      return;
+    }
+
+    const { body } = req;
+    const { jobId, buildId, imageRepo, imageName, friendlyTag, specificTag, digest } = body;
+    const dockerInfo: DockerInfo = { imageRepo, imageName, friendlyTag, specificTag, digest };
+
+    await CiBuilds.markBuildAsPublished(buildId, dockerInfo);
+    const jobHasCompleted = await CiBuilds.haveAllBuildsForJobBeenPublished(jobId);
+    firebase.logger.info('Publication reported.', body);
+
+    if (jobHasCompleted) {
+      await CiJobs.markJobAsCompleted(jobId);
+      const message = `Job completed for ${jobId}.`;
+      firebase.logger.info(message);
+      await Discord.sendMessageToMaintainers(message);
+    }
+
+    res.status(200).send('OK');
+  } catch (err) {
+    const message = `
+      Something went wrong while wrong while reporting a new publication
+      ${err.message} (${err.status})\n${err.stackTrace}
+    `;
+    firebase.logger.error(message);
+    await Discord.sendAlert(message);
+    res.status(500).send('Something went wrong');
+  } finally {
+    await Discord.disconnect();
   }
-
-  firebase.logger.info('Publication reported.', req);
-
-  res.status(200).send('OK');
 });

--- a/functions/src/api/reportPublication.ts
+++ b/functions/src/api/reportPublication.ts
@@ -8,8 +8,8 @@ import { Discord } from '../config/discord';
 
 export const reportPublication = functions.https.onRequest(async (req: Request, res: Response) => {
   try {
-    if (!Token.isValid(req.header('Authorisation'))) {
-      firebase.logger.warn('unauthorised request', req);
+    if (!Token.isValid(req.header('authorization'))) {
+      firebase.logger.warn('unauthorised request', req.headers);
       res.status(403).send('Unauthorized');
       return;
     }

--- a/functions/src/api/unityVersions.ts
+++ b/functions/src/api/unityVersions.ts
@@ -1,12 +1,12 @@
 import { Request } from 'firebase-functions/lib/providers/https';
 import { Response } from 'express-serve-static-core';
 import { firebase, functions } from '../config/firebase';
-import { UnityVersionInfo } from '../model/unityVersionInfo';
+import { EditorVersionInfo } from '../model/editorVersionInfo';
 
 export const unityVersions = functions.https.onRequest(
   async (request: Request, response: Response) => {
     try {
-      const versions = await UnityVersionInfo.getAllIds();
+      const versions = await EditorVersionInfo.getAllIds();
 
       response.send(versions);
     } catch (err) {

--- a/functions/src/config/discord.ts
+++ b/functions/src/config/discord.ts
@@ -37,8 +37,8 @@ export class Discord {
       const i = await this.getInstance();
 
       // Todo - retry mechanism
-
       await i.createMessage(channelId, message, files);
+      await this.disconnect();
       return true;
     } catch (err) {
       firebase.logger.error('An error occurred while trying to send a message to discord.', err);

--- a/functions/src/config/discord.ts
+++ b/functions/src/config/discord.ts
@@ -72,7 +72,7 @@ export class Discord {
       await new Promise((resolve) => setTimeout(resolve, 1000));
       secondsWaited += 1;
 
-      if (secondsWaited >= 8) {
+      if (secondsWaited >= 15) {
         throw new Error('Bot never became ready');
       }
     }

--- a/functions/src/cron/index.ts
+++ b/functions/src/cron/index.ts
@@ -20,8 +20,6 @@ export const trigger = functions.pubsub
 
       firebase.logger.error(message);
       await Discord.sendAlert(message);
-    } finally {
-      await Discord.disconnect();
     }
   });
 

--- a/functions/src/logic/buildQueue/generateBuildQueueFromNewVersionInfo.ts
+++ b/functions/src/logic/buildQueue/generateBuildQueueFromNewVersionInfo.ts
@@ -1,8 +1,8 @@
-import { UnityVersionInfo } from '../../model/unityVersionInfo';
+import { EditorVersionInfo } from '../../model/editorVersionInfo';
 import { db } from '../../config/firebase';
 
 export const generateBuildQueueFromNewVersionInfoList = async (
-  versionInfoList: UnityVersionInfo[],
+  versionInfoList: EditorVersionInfo[],
 ) => {
   const batch = db.batch();
 

--- a/functions/src/logic/ingestUnityVersions/index.ts
+++ b/functions/src/logic/ingestUnityVersions/index.ts
@@ -15,7 +15,5 @@ export const ingestUnityVersions = async () => {
 
     firebase.logger.error(message);
     await Discord.sendAlert(message);
-  } finally {
-    await Discord.disconnect();
   }
 };

--- a/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
+++ b/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
@@ -1,12 +1,12 @@
 import { getDocumentFromUrl } from '../utils/get-document-from-url';
-import { UnityVersionInfo } from '../../model/unityVersionInfo';
+import { EditorVersionInfo } from '../../model/editorVersionInfo';
 
 const UNITY_ARCHIVE_URL = 'https://unity3d.com/get-unity/download/archive';
 
 /**
  * Based on https://github.com/BLaZeKiLL/unity-scraper
  */
-export const scrapeVersions = async (): Promise<UnityVersionInfo[]> => {
+export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
   const document = await getDocumentFromUrl(UNITY_ARCHIVE_URL);
 
   const links = Array.from(document.querySelectorAll('a.unityhub[href]'));

--- a/functions/src/logic/ingestUnityVersions/updateDatabase.ts
+++ b/functions/src/logic/ingestUnityVersions/updateDatabase.ts
@@ -1,4 +1,4 @@
-import { UnityVersionInfo } from '../../model/unityVersionInfo';
+import { EditorVersionInfo } from '../../model/editorVersionInfo';
 import { isMatch } from 'lodash';
 import { firebase } from '../../config/firebase';
 import { Discord } from '../../config/discord';
@@ -7,11 +7,11 @@ const plural = (amount: number) => {
   return amount === 1 ? 'version' : 'versions';
 };
 
-export const updateDatabase = async (ingestedInfoList: UnityVersionInfo[]): Promise<void> => {
-  const existingInfoList = await UnityVersionInfo.getAll();
+export const updateDatabase = async (ingestedInfoList: EditorVersionInfo[]): Promise<void> => {
+  const existingInfoList = await EditorVersionInfo.getAll();
 
-  const newVersions: UnityVersionInfo[] = [];
-  const updatedVersions: UnityVersionInfo[] = [];
+  const newVersions: EditorVersionInfo[] = [];
+  const updatedVersions: EditorVersionInfo[] = [];
 
   ingestedInfoList.forEach((scrapedInfo) => {
     const { version } = scrapedInfo;
@@ -31,12 +31,12 @@ export const updateDatabase = async (ingestedInfoList: UnityVersionInfo[]): Prom
   let message = '';
 
   if (newVersions.length >= 1) {
-    await UnityVersionInfo.createMany(newVersions);
+    await EditorVersionInfo.createMany(newVersions);
     message += `${newVersions.length} new ${plural(newVersions.length)} detected. `;
   }
 
   if (updatedVersions.length >= 1) {
-    await UnityVersionInfo.updateMany(updatedVersions);
+    await EditorVersionInfo.updateMany(updatedVersions);
     message += `${updatedVersions.length} updated ${plural(updatedVersions.length)} detected. `;
   }
 

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -1,6 +1,5 @@
 import { db, admin, firebase } from '../config/firebase';
 import Timestamp = admin.firestore.Timestamp;
-import { RepoVersionInfo } from './repoVersions';
 import FieldValue = admin.firestore.FieldValue;
 
 const COLLECTION = 'ciBuilds';
@@ -14,7 +13,7 @@ enum BuildStatus {
 type ImageType = 'base' | 'hub' | 'editor';
 
 // Used in Start API
-export interface BuildVersionInfo {
+export interface BuildInfo {
   baseOs: string;
   repoVersion: string;
   unityVersion: string;
@@ -32,7 +31,7 @@ export interface DockerInfo {
   imageName: string;
   friendlyTag: string;
   specificTag: string;
-  hash: string;
+  digest: string;
   // date with docker as source of truth?
 }
 
@@ -44,12 +43,12 @@ interface MetaData {
 }
 
 export interface CiBuild {
-  jobId: string;
-  BuildId: string;
+  buildId: string;
+  relatedJobId: string;
   status: BuildStatus;
   imageType: ImageType;
   meta: MetaData;
-  unityVersionInfo: BuildVersionInfo;
+  buildInfo: BuildInfo;
   failure: BuildFailure | null;
   dockerInfo: DockerInfo | null;
   addedDate: Timestamp;
@@ -68,30 +67,32 @@ export class CiBuilds {
     return snapshot.docs.map((doc) => doc.data()) as CiBuild[];
   };
 
-  static create = async (
-    jobId: string,
+  static registerNewBuild = async (
+    buildId: string,
+    relatedJobId: string,
     imageType: ImageType,
-    buildVersionInfo: BuildVersionInfo,
-    repoVersionInfo: RepoVersionInfo,
+    buildInfo: BuildInfo,
   ) => {
     try {
-      await db
-        .collection(COLLECTION)
-        .doc('some elaborate id')
-        .set({
-          jobId,
-          imageType,
-          status: BuildStatus.started,
-          buildVersionInfo,
-          failure: null,
-          meta: {
-            lastBuildStart: Timestamp.now(),
-            failureCount: 0,
-            lastBuildFailure: null,
-          },
-          addedDate: Timestamp.now(),
-          modifiedDate: Timestamp.now(),
-        });
+      const data: CiBuild = {
+        status: BuildStatus.started,
+        buildId,
+        relatedJobId,
+        imageType,
+        buildInfo,
+        failure: null,
+        dockerInfo: null,
+        meta: {
+          lastBuildStart: Timestamp.now(),
+          failureCount: 0,
+          lastBuildFailure: null,
+          publishedDate: null,
+        },
+        addedDate: Timestamp.now(),
+        modifiedDate: Timestamp.now(),
+      };
+
+      await db.collection(COLLECTION).doc(buildId).set({ data });
     } catch (err) {
       firebase.logger.error('Error occurred while trying to enqueue a new build', err);
     }
@@ -118,5 +119,19 @@ export class CiBuilds {
       modifiedDate: Timestamp.now(),
       'meta.publishedDate': Timestamp.now(),
     });
+  };
+
+  static haveAllBuildsForJobBeenPublished = async (jobId: string): Promise<boolean> => {
+    const snapshot = await db
+      .collection(COLLECTION)
+      .where('jobId', '==', jobId)
+      // @ts-ignore
+      .where('status', '!=', BuildStatus.published)
+      .limit(1)
+      .get();
+
+    firebase.logger.info(snapshot.docs);
+
+    return snapshot.docs.length <= 1;
   };
 }

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -10,13 +10,13 @@ enum BuildStatus {
   published,
 }
 
-type ImageType = 'base' | 'hub' | 'editor';
+export type ImageType = 'base' | 'hub' | 'editor';
 
 // Used in Start API
 export interface BuildInfo {
   baseOs: string;
   repoVersion: string;
-  unityVersion: string;
+  editorVersion: string;
   targetPlatform: string;
 }
 

--- a/functions/src/model/ciJobs.ts
+++ b/functions/src/model/ciJobs.ts
@@ -61,10 +61,10 @@ export class CiJobs {
     }
   };
 
-  static reportBuildStart = async (id: string) => {
-    const build = await db.collection(COLLECTION).doc(id);
+  static markJobAsInProgress = async (jobId: string) => {
+    const job = await db.collection(COLLECTION).doc(jobId);
 
-    const snapshot = await build.get();
+    const snapshot = await job.get();
     const currentBuild = snapshot.data() as CiJob;
 
     // TODO - move this logic out of the model
@@ -74,17 +74,17 @@ export class CiJobs {
       status = JobStatus.inProgress;
     }
 
-    await build.update({
+    await job.update({
       status,
       'meta.lastBuildStart': Timestamp.now(),
       modifiedDate: Timestamp.now(),
     });
   };
 
-  static reportBuildFailure = async (id: string) => {
-    const build = await db.collection(COLLECTION).doc(id);
+  static markFailureForJob = async (jobId: string) => {
+    const job = await db.collection(COLLECTION).doc(jobId);
 
-    await build.update({
+    await job.update({
       status: JobStatus.failure,
       'meta.failures': FieldValue.increment(1),
       'meta.lastBuildFailure': Timestamp.now(),
@@ -92,10 +92,10 @@ export class CiJobs {
     });
   };
 
-  static markJobAsCompleted = async (id: string) => {
-    const build = await db.collection(COLLECTION).doc(id);
+  static markJobAsCompleted = async (jobId: string) => {
+    const job = await db.collection(COLLECTION).doc(jobId);
 
-    await build.update({
+    await job.update({
       status: JobStatus.completed,
       modifiedDate: Timestamp.now(),
     });

--- a/functions/src/model/ciVersionInfo.ts
+++ b/functions/src/model/ciVersionInfo.ts
@@ -1,11 +1,13 @@
 import { db, admin, firebase } from '../config/firebase';
 import Timestamp = admin.firestore.Timestamp;
-import { UnityVersionInfo } from './unityVersionInfo';
+import { EditorVersionInfo } from './editorVersionInfo';
+import { RepoVersionInfo } from './repoVersions';
 
 const COLLECTION = 'builtVersions';
 
 export interface CiVersionInfo {
-  unityVersionInfo: UnityVersionInfo;
+  editorVersion: EditorVersionInfo;
+  repoVersion: RepoVersionInfo;
   addedDate?: Timestamp;
   modifiedDate?: Timestamp;
 }
@@ -14,23 +16,24 @@ export class CiVersionInfo {
   static getAll = async (): Promise<CiVersionInfo[]> => {
     const snapshot = await db
       .collection(COLLECTION)
-      .orderBy('unityVersionInfo.major', 'desc')
-      .orderBy('unityVersionInfo.minor', 'desc')
-      .orderBy('unityVersionInfo.patch', 'desc')
+      .orderBy('editorVersion.major', 'desc')
+      .orderBy('editorVersion.minor', 'desc')
+      .orderBy('editorVersion.patch', 'desc')
+      .orderBy('repoVersion.major', 'desc')
+      .orderBy('repoVersion.minor', 'desc')
+      .orderBy('repoVersion.patch', 'desc')
       .get();
 
     return snapshot.docs.map((doc) => doc.data()) as CiVersionInfo[];
   };
 
-  static create = async (builtVersion: CiVersionInfo) => {
+  static create = async (editorVersion: EditorVersionInfo, repoVersion: RepoVersionInfo) => {
     try {
-      await db
-        .collection(COLLECTION)
-        .doc('some elaborate id')
-        .set({
-          ...builtVersion,
-          addedDate: Timestamp.now(),
-        });
+      await db.collection(COLLECTION).doc('some elaborate id').set({
+        editorVersion,
+        repoVersion,
+        addedDate: Timestamp.now(),
+      });
     } catch (err) {
       firebase.logger.error('Error occurred during batch commit of new version', err);
     }

--- a/functions/src/model/editorVersionInfo.ts
+++ b/functions/src/model/editorVersionInfo.ts
@@ -3,7 +3,7 @@ import Timestamp = admin.firestore.Timestamp;
 
 const COLLECTION = 'unityVersions';
 
-export interface UnityVersionInfo {
+export interface EditorVersionInfo {
   version: string;
   changeSet: string;
   major: number;
@@ -13,7 +13,13 @@ export interface UnityVersionInfo {
   modifiedDate?: Timestamp;
 }
 
-export class UnityVersionInfo {
+export class EditorVersionInfo {
+  static get = async (version: string): Promise<EditorVersionInfo> => {
+    const snapshot = await db.collection(COLLECTION).doc(version).get();
+
+    return snapshot.data() as EditorVersionInfo;
+  };
+
   static getAllIds = async (): Promise<string[]> => {
     const snapshot = await db
       .collection(COLLECTION)
@@ -25,7 +31,7 @@ export class UnityVersionInfo {
     return snapshot.docs.map((doc) => doc.id);
   };
 
-  static getAll = async (): Promise<UnityVersionInfo[]> => {
+  static getAll = async (): Promise<EditorVersionInfo[]> => {
     const snapshot = await db
       .collection(COLLECTION)
       .orderBy('major', 'desc')
@@ -33,10 +39,10 @@ export class UnityVersionInfo {
       .orderBy('patch', 'desc')
       .get();
 
-    return snapshot.docs.map((doc) => doc.data()) as UnityVersionInfo[];
+    return snapshot.docs.map((doc) => doc.data()) as EditorVersionInfo[];
   };
 
-  static createMany = async (versionInfoList: UnityVersionInfo[]) => {
+  static createMany = async (versionInfoList: EditorVersionInfo[]) => {
     try {
       const batch = db.batch();
 
@@ -54,7 +60,7 @@ export class UnityVersionInfo {
     }
   };
 
-  static updateMany = async (versionInfoList: UnityVersionInfo[]) => {
+  static updateMany = async (versionInfoList: EditorVersionInfo[]) => {
     try {
       const batch = db.batch();
 


### PR DESCRIPTION
#### Changes

- populate reporting endpoints
- add dryRun capability
- rename UnityVersion to EditorVersion, as base and hub images have nothing to do with it.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
