### PR TITLE
schedule different kinds of jobs

### DIFF
--- a/functions/src/logic/buildQueue/scheduler.ts
+++ b/functions/src/logic/buildQueue/scheduler.ts
@@ -243,7 +243,7 @@ export class Scheduler {
   private static getEventTypeForEditorJob(editorVersionInfo: EditorVersionInfo) {
     const { major, minor } = editorVersionInfo;
 
-    if (major >= 2019 && minor >= 3) {
+    if (major >= 2020 || (major === 2019 && minor >= 3)) {
       return 'new_2019_3_plus_editor_image_requested';
     } else {
       return 'new_legacy_editor_image_requested';

--- a/functions/src/logic/buildQueue/scheduler.ts
+++ b/functions/src/logic/buildQueue/scheduler.ts
@@ -204,13 +204,15 @@ export class Scheduler {
     firebase.logger.info('[Scheduler] took this from the queue', toBeScheduledJobs);
     for (const toBeScheduledJob of toBeScheduledJobs) {
       const { id: jobId, data } = toBeScheduledJob;
-      const { editorVersionInfo } = data;
-      const { version: editorVersion, changeSet } = editorVersionInfo as EditorVersionInfo;
+
+      const editorVersionInfo = data.editorVersionInfo as EditorVersionInfo;
+      const { version: editorVersion, changeSet } = editorVersionInfo;
+      const eventType = Scheduler.getEventTypeForEditorJob(editorVersionInfo);
 
       const response = await this.gitHub.repos.createDispatchEvent({
         owner: 'unity-ci',
         repo: 'docker',
-        event_type: 'new_editor_image_requested',
+        event_type: eventType,
         client_payload: {
           jobId,
           editorVersion,
@@ -236,6 +238,16 @@ export class Scheduler {
 
     // The queue was not empty, so we're not happy yet
     return false;
+  }
+
+  private static getEventTypeForEditorJob(editorVersionInfo: EditorVersionInfo) {
+    const { major, minor } = editorVersionInfo;
+
+    if (major >= 2019 && minor >= 3) {
+      return 'new_2019_3_plus_editor_image_requested';
+    } else {
+      return 'new_legacy_editor_image_requested';
+    }
   }
 
   private async determineOpenSpots(): Promise<number> {


### PR DESCRIPTION
#### Changes

- This dispatches different actions based on the editorVersions. We'll duplicate the whole workflow every time a version threshold from unity has different dependencies, so the matrix has to be changed.

Unfortunately we can not [exit the workflow early yet](https://github.com/actions/runner/issues/662) and matrices are not flexible enough to do wildcards like attempted [here](https://github.com/Unity-CI/docker/pull/31/commits/e510db8b80de36aee6fe5d08e26e383b0e1df29a#diff-1bbd4c7dc825f8b65d25d7555ffdb56035eb508a74668193773b7033938c24d3R47) as a quick hack.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
