### PR TITLE
Add more fine-grained control to the queue worker

### DIFF
--- a/functions/src/config/settings.ts
+++ b/functions/src/config/settings.ts
@@ -1,6 +1,8 @@
 export const settings = {
-  maxConcurrentJobs: 5,
-  maxFailuresPerBuild: 5,
+  maxConcurrentJobs: 9,
+  maxExtraJobsForRescheduling: 1,
+  maxToleratedFailures: 2,
+  maxFailuresPerBuild: 15,
   discord: {
     channels: {
       news: '731947345478156391',


### PR DESCRIPTION
#### Changes

- Up the number of concurrent jobs to 10 (times the number of platforms)
- Reserve at least one spot for rescheduling failed builds
- Allow continuing to build more images, even when 1 or 2 have failed (but stop new builds if there are more failures)
- Set the retry limit to 15 (every retry will wait an additional 15 minutes before retrying, so almost 4 hours after 14 failures).

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
