### PR TITLE
Only log to discord once per maxRetriesReached

### DIFF
--- a/functions/src/config/settings.ts
+++ b/functions/src/config/settings.ts
@@ -1,4 +1,5 @@
 export const settings = {
+  minutesBetweenScans: 15,
   maxConcurrentJobs: 9,
   maxExtraJobsForRescheduling: 1,
   maxToleratedFailures: 2,

--- a/functions/src/cron/index.ts
+++ b/functions/src/cron/index.ts
@@ -4,6 +4,12 @@ import { Discord } from '../config/discord';
 import { ingestUnityVersions } from '../logic/ingestUnityVersions';
 import { ingestRepoVersions } from '../logic/ingestRepoVersions';
 import { scheduleBuildsFromTheQueue } from '../logic/buildQueue';
+import { settings } from '../config/settings';
+
+const MINUTES: number = settings.minutesBetweenScans;
+if (MINUTES < 10) {
+  throw new Error('Is the result really worth the machine time? Remove me.');
+}
 
 /**
  * CPU-time for pubSub is not part of the free quota, so we'll keep it light weight.
@@ -11,7 +17,7 @@ import { scheduleBuildsFromTheQueue } from '../logic/buildQueue';
  */
 export const trigger = functions
   .runWith({ timeoutSeconds: 60, memory: '512MB' })
-  .pubsub.schedule('every 15 minutes')
+  .pubsub.schedule(`every ${MINUTES} minutes`)
   .onRun(async (context: EventContext) => {
     try {
       await routineTasks();


### PR DESCRIPTION
#### Changes

- This will move the setting for how often to run the scan cronjob to the settings.
- The cron will warn if it is being set to run more often than once per 10 minutes.
- The error that maintainers were being spammed with is now only outputting once per maxRetriesReached per build.
- That error is now reported as a warning in firebase.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
