### PR TITLE
deprecate unity <= 2018.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Install firebase globally
 
 ```bash
-npm i -g firebase
+npm i -g firebase-tools
 ```
 
 Install dependencies

--- a/functions/src/model/ciJobs.ts
+++ b/functions/src/model/ciJobs.ts
@@ -16,7 +16,8 @@ export type JobStatus =
   | 'inProgress'
   | 'completed'
   | 'failed'
-  | 'superseded';
+  | 'superseded'
+  | 'deprecated';
 
 interface MetaData {
   lastBuildStart: Timestamp | null;
@@ -138,8 +139,17 @@ export class CiJobs {
     repoVersionInfo: RepoVersionInfo,
     editorVersionInfo: EditorVersionInfo | null = null,
   ): CiJob => {
+    let status: JobStatus = 'deprecated';
+    if (
+      editorVersionInfo === null ||
+      editorVersionInfo.major >= 2019 ||
+      (editorVersionInfo.major === 2018 && editorVersionInfo.minor >= 2)
+    ) {
+      status = 'created';
+    }
+
     const job: CiJob = {
-      status: 'created',
+      status,
       imageType,
       repoVersionInfo,
       editorVersionInfo,


### PR DESCRIPTION
#### Changes

- This will no longer schedule any build before 2018.2 as older versions are now deprecated. They are deprecated because they require manual setup and NDK versions can not reliably be determined programmatically.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
