### PR TITLE
feat: scrape available alpha/beta versions

### DIFF
--- a/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
+++ b/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
@@ -2,6 +2,7 @@ import { getDocumentFromUrl } from '../utils/get-document-from-url';
 import { EditorVersionInfo } from '../../model/editorVersionInfo';
 
 const UNITY_ARCHIVE_URL = 'https://unity3d.com/get-unity/download/archive';
+const UNITY_BETA_URL = 'https://unity3d.com/beta';
 
 /**
  * Based on https://github.com/BLaZeKiLL/unity-scraper
@@ -12,7 +13,7 @@ export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
   const links = Array.from(document.querySelectorAll('a.unityhub[href]'));
   const hrefs = links.map((a) => a.getAttribute('href')) as string[];
 
-  const versionInfoList = hrefs.map((href) => {
+  const versionInfoList = hrefs.concat(await scrapeBetaVersions()).map((href) => {
     const info = href.replace('unityhub://', '');
     const [version, changeSet] = info.split('/');
     const [major, minor, patch] = version.split('.');
@@ -27,4 +28,41 @@ export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
   });
 
   return versionInfoList;
+};
+
+/**
+ * Scrape available alpha/beta versions from https://unity3d.com/beta
+ */
+const scrapeBetaVersions = async (): Promise<string[]> => {
+  const document = await getDocumentFromUrl(UNITY_BETA_URL);
+
+  const betas = new Set<string>();
+  Array.from(document.querySelectorAll('a[href]'))
+    .map((a) => a.getAttribute('href') as string)
+    .filter((href) => /^\/(alpha|beta)\/\d{4}\.\d(a|b)$/.test(href))
+    .forEach((href) => betas.add(href));
+
+  const downloads = new Set<string>();
+  for (const beta of betas) {
+    // [beta page] e.g. 'https://unity3d.com/beta/2020.2b'
+    const betaPage = await getDocumentFromUrl(`https://unity3d.com${beta}`);
+    Array.from(betaPage.querySelectorAll('a[href]'))
+      .map((a) => a.getAttribute('href') as string)
+      // [filter] e.g. '/unity/beta/2020.2.0b13'
+      .filter((href) => /^\/unity\/(alpha|beta)\/\d{4}\.\d+\.\d+(a|b)\d+$/.test(href))
+      .forEach((href) => downloads.add(href));
+  }
+
+  const hrefs = new Set<string>();
+  for (const download of downloads) {
+    // [download page] e.g. https://unity3d.com/unity/beta/2020.2.0b13
+    const downloadPage = await getDocumentFromUrl(`https://unity3d.com${download}`);
+    Array.from(downloadPage.querySelectorAll('a[href]'))
+      .map((a) => a.getAttribute('href') as string)
+      // [filter] e.g. 'unityhub://2020.2.0b13/655e1a328b90'
+      .filter((href) => /^unityhub:\/\/\d{4}\.\d+\.\d+(a|b)\d+\/\w{12}$/.test(href))
+      .forEach((href) => hrefs.add(href));
+  }
+
+  return Array.from(hrefs);
 };


### PR DESCRIPTION
#### Changes

- Scrape available alpha/beta versions from https://unity3d.com/beta
  - Users can use the alpha/beta version of Unity.
  - CI failure log will help you to find the missing libraries.
  - The version that disappeared from the beta page will not be tracked.
    - The version(f) has been released.
    - The version(a/b) and is obsolete.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
