### PR TITLE
Allow admins to retryBuilds using ingeminator

### DIFF
--- a/functions/src/api/index.ts
+++ b/functions/src/api/index.ts
@@ -4,3 +4,4 @@ export { reportNewBuild } from './reportNewBuild';
 export { reportPublication } from './reportPublication';
 export { unityVersions } from './unityVersions';
 export { manualWorkflowTrigger } from './manualWorkflowTrigger';
+export { retryBuild } from './retryBuild';

--- a/functions/src/api/retryBuild.ts
+++ b/functions/src/api/retryBuild.ts
@@ -1,0 +1,93 @@
+import { functions, admin } from '../config/firebase';
+import { Request } from 'firebase-functions/lib/providers/https';
+import { Response } from 'express-serve-static-core';
+import { CiBuilds } from '../model/ciBuilds';
+import { CiJobs } from '../model/ciJobs';
+import { Ingeminator } from '../logic/buildQueue/ingeminator';
+import { GitHub } from '../config/github';
+import { RepoVersionInfo } from '../model/repoVersionInfo';
+
+export const retryBuild = functions.https.onRequest(
+  async (request: Request, response: Response) => {
+    try {
+      response.set('Content-Type', 'application/json');
+
+      // Allow pre-flight from cross origin
+      response.set('Access-Control-Allow-Origin', '*');
+      response.set('Access-Control-Allow-Methods', ['POST']);
+      response.set('Access-Control-Allow-Headers', ['Content-Type', 'Authorization']);
+      if (request.method === 'OPTIONS') {
+        response.status(204).send({ message: 'OK' });
+        return;
+      }
+
+      // User must be authenticated
+      const token = request.header('Authorization')?.replace(/^Bearer\s/, '');
+      console.log('token:', token);
+      if (!token) {
+        response.status(401).send({ message: 'Unauthorized' });
+        return;
+      }
+
+      // User must be an admin
+      const user = await admin.auth().verifyIdToken(token);
+      if (!user || !user.email_verified || !user.admin) {
+        response.status(401).send({ message: 'Unauthorized' });
+        return;
+      }
+
+      // Validate arguments
+      const { buildId, relatedJobId: jobId } = request.body;
+      if (!buildId || !jobId) {
+        response.status(400);
+        response.send({
+          message: 'Bad request',
+          description: 'Expected buildId and relatedJobId.',
+        });
+        return;
+      }
+
+      // Only retry existing builds
+      const [job, build] = await Promise.all([CiJobs.get(jobId), CiBuilds.get(buildId)]);
+      if (!job || !build) {
+        response.status(400);
+        response.send({
+          message: 'Bad request',
+          description: 'Expected valid buildId and relatedJobId.',
+        });
+        return;
+      }
+
+      // Check if build is not already running
+      if (build.status === 'started') {
+        response.status(409);
+        response.send({
+          message: 'Build was already re-scheduled',
+          description: request.body.buildId,
+        });
+        return;
+      }
+
+      // Schedule new build
+      const gitHubClient = await GitHub.init();
+      const repoVersionInfo = await RepoVersionInfo.getLatest();
+      const scheduler = new Ingeminator(1, gitHubClient, repoVersionInfo);
+      const scheduledSuccessfully = await scheduler.rescheduleBuild(jobId, job, buildId, build);
+
+      // Report result
+      if (scheduledSuccessfully) {
+        response.status(200);
+        response.send({ message: 'Build has been rescheduled', description: request.body.buildId });
+      } else {
+        response.status(408);
+        response.send({
+          message: 'Request to Dockerhub timed out',
+          description: request.body.buildId,
+        });
+      }
+    } catch (error) {
+      console.log('error', JSON.stringify(error, Object.getOwnPropertyNames(error)));
+      response.status(401).send({ message: 'Unauthorized' });
+    }
+  },
+);

--- a/functions/src/logic/buildQueue/ingeminator.ts
+++ b/functions/src/logic/buildQueue/ingeminator.ts
@@ -103,12 +103,7 @@ export class Ingeminator {
     firebase.logger.debug(`[Ingeminator] rescheduled any failing editor images for ${jobId}.`);
   }
 
-  private async rescheduleBuild(
-    jobId: string,
-    jobData: CiJob,
-    buildId: string,
-    buildData: CiBuild,
-  ) {
+  public async rescheduleBuild(jobId: string, jobData: CiJob, buildId: string, buildData: CiBuild) {
     // Info from job
     const { editorVersionInfo } = jobData;
     const { version: editorVersion, changeSet } = editorVersionInfo as EditorVersionInfo;

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -66,6 +66,16 @@ export class CiBuilds {
     return snapshot.docs.map((doc) => doc.data()) as CiBuild[];
   };
 
+  static get = async (buildId: string): Promise<CiBuild | null> => {
+    const snapshot = await db.doc(`${CI_BUILDS_COLLECTION}/${buildId}`).get();
+
+    if (!snapshot.exists) {
+      return null;
+    }
+
+    return snapshot.data() as CiBuild;
+  };
+
   static getFailedBuildsQueue = async (jobId: string): Promise<CiBuildQueue> => {
     const snapshot = await db
       .collection(CI_BUILDS_COLLECTION)


### PR DESCRIPTION
#### Changes

- This adds an endpoint that is accessible for admins (using bearer token acquired from firebase auth)
- The endpoint reschedules a job that has failed before, ignoring max-retries.

This should allow admins to unstuck builds in an easy manner if it is clear what the cause of the failure is.

Most often this is due to timeouts in dockerhub, in which case we delete the tag that we check for existance and rebuild.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
