### PR TITLE
feat: add verbose logging to discord

### DIFF
--- a/functions/src/config/discord.ts
+++ b/functions/src/config/discord.ts
@@ -7,52 +7,74 @@ const { token } = firebase.config().discord;
 let instance: Eris.Client | null = null;
 
 export class Discord {
+  static async sendDebug(
+    message: Eris.MessageContent,
+    files: Eris.MessageFile | Eris.MessageFile[] | undefined = undefined,
+  ): Promise<boolean> {
+    firebase.logger.info(message);
+
+    // Set to null as we don't differ between debug/info yet. Null is debug.
+    return this.sendMessage(null, message, files, 'info');
+  }
+
   static async sendNews(
     message: Eris.MessageContent,
     files: Eris.MessageFile | Eris.MessageFile[] | undefined = undefined,
   ): Promise<boolean> {
-    return this.sendMessage(settings.discord.channels.news, message, files);
+    return this.sendMessage(settings.discord.channels.news, message, files, 'info');
   }
 
   static async sendAlert(
     message: Eris.MessageContent,
     files: Eris.MessageFile | Eris.MessageFile[] | undefined = undefined,
   ): Promise<boolean> {
-    return this.sendMessage(settings.discord.channels.alerts, message, files);
+    return this.sendMessage(settings.discord.channels.alerts, message, files, 'error');
   }
 
   static async sendMessageToMaintainers(
     message: Eris.MessageContent,
     files: Eris.MessageFile | Eris.MessageFile[] | undefined = undefined,
   ): Promise<boolean> {
-    return this.sendMessage(settings.discord.channels.maintainers, message, files);
+    return this.sendMessage(settings.discord.channels.maintainers, message, files, 'info');
   }
 
   static async sendMessage(
-    channelId: string,
+    channelId: string | null,
     messageContent: Eris.MessageContent,
     files: Eris.MessageFile | Eris.MessageFile[] | undefined = undefined,
+    level: 'debug' | 'info' | 'warn' | 'error' | 'critical',
   ): Promise<boolean> {
-    let success = false;
+    let isSent = false;
     try {
       const discord = await this.getInstance();
 
       if (typeof messageContent === 'string') {
         for (const message of Discord.splitMessage(messageContent)) {
-          await discord.createMessage(channelId, message, files);
+          if (channelId) await discord.createMessage(channelId, message, files);
+
+          // Also send to debug channel
+          await discord.createMessage(
+            settings.discord.channels.debug,
+            `[${level}] ${message}`,
+            files,
+          );
         }
       } else {
-        await discord.createMessage(channelId, messageContent, files);
+        if (channelId) await discord.createMessage(channelId, messageContent, files);
+
+        // Also send to debug channel
+        messageContent.content = `[${level}] ${messageContent.content}`;
+        await discord.createMessage(settings.discord.channels.debug, messageContent, files);
       }
 
-      success = true;
+      isSent = true;
     } catch (err) {
       firebase.logger.error('An error occurred while trying to send a message to discord.', err);
     } finally {
       await this.disconnect();
     }
 
-    return success;
+    return isSent;
   }
 
   static async getInstance(): Promise<Eris.Client> {
@@ -94,7 +116,8 @@ export class Discord {
     instance = null;
   }
 
-  static splitMessage(message: string, maxMessageSize: number = 1950): Array<string> {
+  // Max message size must account for ellipsis and level parts that are added to the message.
+  static splitMessage(message: string, maxMessageSize: number = 1940): Array<string> {
     const numberOfMessages = Math.ceil(message.length / maxMessageSize);
     const messages: Array<string> = new Array<string>(numberOfMessages);
 

--- a/functions/src/config/settings.ts
+++ b/functions/src/config/settings.ts
@@ -7,9 +7,10 @@ export const settings = {
   maxFailuresPerBuild: 15,
   discord: {
     channels: {
-      news: '731947345478156391',
-      maintainers: '764289922663841792',
-      alerts: '763544776649605151',
+      news: '731947345478156391', // #news (public)
+      maintainers: '764289922663841792', // # build-notifications (internal)
+      alerts: '763544776649605151', // #alerts (internal)
+      debug: '815382556143910953', // #backend (internal)
     },
   },
   github: {

--- a/functions/src/logic/buildQueue/scheduleBuildsFromTheQueue.ts
+++ b/functions/src/logic/buildQueue/scheduleBuildsFromTheQueue.ts
@@ -1,6 +1,6 @@
 import { RepoVersionInfo } from '../../model/repoVersionInfo';
-import { firebase } from '../../config/firebase';
 import { Scheduler } from './scheduler';
+import { Discord } from '../../config/discord';
 
 /**
  * When a new Unity version gets ingested:
@@ -20,29 +20,29 @@ export const scheduleBuildsFromTheQueue = async () => {
 
   const testVersion = '0.1.0';
   if (repoVersionInfo.version === testVersion) {
-    firebase.logger.info('[Build queue] No longer building test versions.');
+    await Discord.sendDebug('[Build queue] No longer building test versions.');
     return;
   }
 
   if (!(await scheduler.ensureThatBaseImageHasBeenBuilt())) {
-    firebase.logger.info('[Build queue] Waiting for base image to be ready.');
+    await Discord.sendDebug('[Build queue] Waiting for base image to be ready.');
     return;
   }
 
   if (!(await scheduler.ensureThatHubImageHasBeenBuilt())) {
-    firebase.logger.info('[Build queue] Waiting for hub image to be ready.');
+    await Discord.sendDebug('[Build queue] Waiting for hub image to be ready.');
     return;
   }
 
   if (!(await scheduler.ensureThereAreNoFailedJobs())) {
-    firebase.logger.info('[Build queue] Retrying failed jobs before scheduling new jobs.');
+    await Discord.sendDebug('[Build queue] Retrying failed jobs before scheduling new jobs.');
     return;
   }
 
   if (!(await scheduler.buildLatestEditorImages())) {
-    firebase.logger.info('[Build queue] Editor images are building.');
+    await Discord.sendDebug('[Build queue] Editor images are building.');
     return;
   }
 
-  firebase.logger.info('[Build queue] Idle 🎈');
+  await Discord.sendDebug('[Build queue] Idle 🎈');
 };

--- a/functions/src/logic/buildQueue/scheduler.ts
+++ b/functions/src/logic/buildQueue/scheduler.ts
@@ -110,7 +110,7 @@ export class Scheduler {
       }
 
       await CiJobs.markJobAsScheduled(jobId);
-      firebase.logger.debug('[Scheduler] Scheduled new base image build', response);
+      await Discord.sendDebug(`[Scheduler] Scheduled new base image build (${jobId}).`);
       return false;
     }
 
@@ -151,7 +151,7 @@ export class Scheduler {
       }
 
       await CiJobs.markJobAsScheduled(jobId);
-      firebase.logger.debug('[Scheduler] Scheduled new hub image build', response);
+      await Discord.sendDebug(`[Scheduler] Scheduled new hub image build (${jobId})`);
       return false;
     }
 
@@ -174,7 +174,7 @@ export class Scheduler {
       const numberToReschedule = openSpots + maxExtraJobsForRescheduling;
 
       if (numberToReschedule <= 0) {
-        firebase.logger.info('[Scheduler] Not retrying any new jobs, as the queue is full');
+        await Discord.sendDebug('[Scheduler] Not retrying any new jobs, as the queue is full');
         return false;
       }
 
@@ -188,7 +188,7 @@ export class Scheduler {
   async buildLatestEditorImages(): Promise<boolean> {
     const openSpots = await this.determineOpenSpots();
     if (openSpots <= 0) {
-      firebase.logger.info('[Scheduler] Not scheduling any new jobs, as the queue is full');
+      await Discord.sendDebug('[Scheduler] Not scheduling any new jobs, as the queue is full');
       return false;
     }
 
@@ -203,7 +203,8 @@ export class Scheduler {
 
     // Schedule each build, one by one
     const toBeScheduledJobs = take(queue, openSpots);
-    firebase.logger.info('[Scheduler] took this from the queue', toBeScheduledJobs);
+    const jobsAsString = toBeScheduledJobs?.map((job) => job.id).join(',\n');
+    await Discord.sendDebug(`[Scheduler] top of the queue: \n ${jobsAsString}`);
     for (const toBeScheduledJob of toBeScheduledJobs) {
       const { id: jobId, data } = toBeScheduledJob;
 
@@ -235,7 +236,7 @@ export class Scheduler {
       }
 
       await CiJobs.markJobAsScheduled(jobId);
-      firebase.logger.debug('[Scheduler] Scheduled new editor image build', response);
+      await Discord.sendDebug(`[Scheduler] Scheduled new editor image build (${jobId}).`);
     }
 
     // The queue was not empty, so we're not happy yet

--- a/functions/src/logic/ingestUnityVersions/updateDatabase.ts
+++ b/functions/src/logic/ingestUnityVersions/updateDatabase.ts
@@ -49,6 +49,6 @@ export const updateDatabase = async (ingestedInfoList: EditorVersionInfo[]): Pro
     firebase.logger.info(message);
     await Discord.sendMessageToMaintainers(message);
   } else {
-    firebase.logger.info('Database is up-to-date. (no updated Unity versions found)');
+    await Discord.sendDebug('Database is up-to-date. (no updated Unity versions found)');
   }
 };

--- a/functions/src/model/ciJobs.ts
+++ b/functions/src/model/ciJobs.ts
@@ -174,7 +174,6 @@ export class CiJobs {
     }
 
     const currentBuild = snapshot.data() as CiJob;
-    firebase.logger.warn(currentBuild);
 
     // Do not override failure or completed
     // In CiJobs, "failure" is used to not race past failed jobs in the buildQueue, whereas


### PR DESCRIPTION
#### Changes

- Adds `sendDebug` to discord logger, which for now also sends logs to firebase, to deduplicate code

In the future we may need a messaging service that decides which types of messages get sent where, but for now this is fine.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
