### PR TITLE
feat: automatically mark as failed or published based on call to dock…

### DIFF
--- a/functions/src/api/reportPublication.ts
+++ b/functions/src/api/reportPublication.ts
@@ -19,12 +19,8 @@ export const reportPublication = functions.https.onRequest(async (req: Request, 
     const isDryRun = req.body.jobId?.toString().startsWith('dryRun');
 
     const { jobId, buildId, dockerInfo } = body;
-    await CiBuilds.markBuildAsPublished(buildId, dockerInfo);
-    const jobHasCompleted = await CiBuilds.haveAllBuildsForJobBeenPublished(jobId);
-
-    if (jobHasCompleted) {
-      await CiJobs.markJobAsCompleted(jobId);
-
+    const parentJobIsNowCompleted = await CiBuilds.markBuildAsPublished(buildId, jobId, dockerInfo);
+    if (parentJobIsNowCompleted) {
       // Report new publications as news
       let message = '';
       if (dockerInfo.imageName === 'editor') {

--- a/functions/src/config/settings.ts
+++ b/functions/src/config/settings.ts
@@ -24,8 +24,9 @@ export const settings = {
   },
   dockerhub: {
     host: 'https://index.docker.io/v1',
-    baseRepository: 'unityci/base',
-    hubRepository: 'unityci/hub',
-    editorRepository: 'unityci/editor',
+    repositoryBaseName: 'unityci',
+    baseImageName: 'base',
+    hubImageName: 'hub',
+    editorImageName: 'editor',
   },
 };

--- a/functions/src/cron/index.ts
+++ b/functions/src/cron/index.ts
@@ -18,14 +18,15 @@ export const trigger = functions
   .onRun(async (context: EventContext) => {
     try {
       await routineTasks();
-    } catch (err) {
-      const message = `
-        Something went wrong while wrong while running routine tasks.
-        ${err.message} (${err.status})\n${err.stackTrace}
-      `;
+    } catch (error) {
+      const errorStatus = error.status ? ` (${error.status})` : '';
+      const errorStack = error.stackTrace ? `\n${error.stackTrace}` : '';
+      const fullError = `${error.message}${errorStatus}${errorStack}`;
 
-      firebase.logger.error(message);
-      await Discord.sendAlert(message);
+      const routineTasksFailedMessage = `Something went wrong while wrong while running routine tasks.\n${fullError}`;
+
+      firebase.logger.error(routineTasksFailedMessage);
+      await Discord.sendAlert(routineTasksFailedMessage);
     }
   });
 

--- a/functions/src/cron/index.ts
+++ b/functions/src/cron/index.ts
@@ -33,10 +33,16 @@ export const trigger = functions
   });
 
 const routineTasks = async () => {
-  await Discord.sendDebugLine('begin');
-  await ingestRepoVersions();
-  await ingestUnityVersions();
-  await cleanUpBuilds();
-  await scheduleBuildsFromTheQueue();
-  await Discord.sendDebugLine('end');
+  try {
+    await Discord.sendDebugLine('begin');
+    await ingestRepoVersions();
+    await ingestUnityVersions();
+    await cleanUpBuilds();
+    await scheduleBuildsFromTheQueue();
+  } catch (error) {
+    firebase.logger.error(error);
+    await Discord.sendAlert(error);
+  } finally {
+    await Discord.sendDebugLine('end');
+  }
 };

--- a/functions/src/cron/index.ts
+++ b/functions/src/cron/index.ts
@@ -23,7 +23,7 @@ export const trigger = functions
       const errorStack = error.stackTrace ? `\n${error.stackTrace}` : '';
       const fullError = `${error.message}${errorStatus}${errorStack}`;
 
-      const routineTasksFailedMessage = `Something went wrong while wrong while running routine tasks.\n${fullError}`;
+      const routineTasksFailedMessage = `Something went wrong while running routine tasks.\n${fullError}`;
 
       firebase.logger.error(routineTasksFailedMessage);
       await Discord.sendAlert(routineTasksFailedMessage);

--- a/functions/src/cron/index.ts
+++ b/functions/src/cron/index.ts
@@ -11,10 +11,7 @@ if (MINUTES < 10) {
   throw new Error('Is the result really worth the machine time? Remove me.');
 }
 
-/**
- * CPU-time for pubSub is not part of the free quota, so we'll keep it light weight.
- * This will call the cloud function `cron/worker`, using an authentication token.
- */
+// Timeout of 60 seconds will keep our routine process tight.
 export const trigger = functions
   .runWith({ timeoutSeconds: 60, memory: '512MB' })
   .pubsub.schedule(`every ${MINUTES} minutes`)

--- a/functions/src/logic/buildQueue/cleaner.ts
+++ b/functions/src/logic/buildQueue/cleaner.ts
@@ -49,7 +49,7 @@ export class Cleaner {
 
         // Image does not exist
         if (!response) {
-          const markAsFailedMessage = `[Cleaner] Build for "${tag}" with status "started" never reported back in. Marking it as failed.`;
+          const markAsFailedMessage = `[Cleaner] Build for "${tag}" with status "started" never reported back in. Marking it as failed. It will retry automatically.`;
           await Discord.sendAlert(markAsFailedMessage);
           await CiBuilds.markBuildAsFailed(buildId, { reason: markAsFailedMessage });
 
@@ -57,7 +57,7 @@ export class Cleaner {
         }
 
         // Image exists
-        const markAsSuccessfulMessage = `[Cleaner] Build for "${tag}" got stuck. But the image was successfully uploaded. Marking it as published`;
+        const markAsSuccessfulMessage = `[Cleaner] Build for "${tag}" got stuck. But the image was successfully uploaded. Marking it as published.`;
         await Discord.sendDebug(markAsSuccessfulMessage);
         await CiBuilds.markBuildAsPublished(buildId, {
           digest: '', // missing

--- a/functions/src/logic/buildQueue/cleaner.ts
+++ b/functions/src/logic/buildQueue/cleaner.ts
@@ -48,7 +48,7 @@ export class Cleaner {
 
         // Image does not exist
         if (!response) {
-          const markAsFailedMessage = `[Cleaner] Build for "${tag}" with status "started" never reported back in. Marking as as failed.`;
+          const markAsFailedMessage = `[Cleaner] Build for "${tag}" with status "started" never reported back in. Marking it as failed.`;
           await Discord.sendAlert(markAsFailedMessage);
           await CiBuilds.markBuildAsFailed(buildId, { reason: markAsFailedMessage });
 
@@ -56,7 +56,7 @@ export class Cleaner {
         }
 
         // Image exists
-        const markAsSuccessfulMessage = `[Cleaner] Build for "${tag}" got stuck. But the image was successfully uploaded. Marking as published`;
+        const markAsSuccessfulMessage = `[Cleaner] Build for "${tag}" got stuck. But the image was successfully uploaded. Marking it as published`;
         await Discord.sendDebug(markAsSuccessfulMessage);
         await CiBuilds.markBuildAsPublished(buildId, {
           digest: '', // missing

--- a/functions/src/logic/buildQueue/cleaner.ts
+++ b/functions/src/logic/buildQueue/cleaner.ts
@@ -8,7 +8,8 @@ export class Cleaner {
   }
 
   public static async cleanUpBuildsThatDidntReportBack() {
-    const startedBuilds = await CiBuilds.getStartedBuilds(12);
+    // Note that the cronjob has a limited runtime, so we can only process so many requests to dockerhub.
+    const startedBuilds = await CiBuilds.getStartedBuilds(6);
 
     for (const startedBuild of startedBuilds) {
       const { buildId, meta, imageType, buildInfo } = startedBuild;

--- a/functions/src/logic/buildQueue/cleaner.ts
+++ b/functions/src/logic/buildQueue/cleaner.ts
@@ -12,7 +12,7 @@ export class Cleaner {
     const startedBuilds = await CiBuilds.getStartedBuilds(6);
 
     for (const startedBuild of startedBuilds) {
-      const { buildId, meta, imageType, buildInfo } = startedBuild;
+      const { buildId, meta, relatedJobId: jobId, imageType, buildInfo } = startedBuild;
       const { publishedDate, lastBuildStart } = meta;
       const { baseOs, repoVersion } = buildInfo;
 
@@ -59,7 +59,7 @@ export class Cleaner {
         // Image exists
         const markAsSuccessfulMessage = `[Cleaner] Build for "${tag}" got stuck. But the image was successfully uploaded. Marking it as published.`;
         await Discord.sendDebug(markAsSuccessfulMessage);
-        await CiBuilds.markBuildAsPublished(buildId, {
+        await CiBuilds.markBuildAsPublished(buildId, jobId, {
           digest: '', // missing
           specificTag: `${baseOs}-${repoVersion}`,
           friendlyTag: repoVersion.replace(/\.\d+$/, ''),

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -76,10 +76,11 @@ export class CiBuilds {
     return snapshot.data() as CiBuild;
   };
 
-  public static getStartedBuilds = async (): Promise<CiBuild[]> => {
+  public static getStartedBuilds = async (limit = 30): Promise<CiBuild[]> => {
     const snapshot = await db
       .collection(CI_BUILDS_COLLECTION)
       .where('status', '==', 'started')
+      .limit(limit)
       .get();
 
     return snapshot.docs.map((doc) => doc.data() as CiBuild);

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -77,11 +77,13 @@ export class CiBuilds {
     return snapshot.data() as CiBuild;
   };
 
-  public static getStartedBuilds = async (limit = 30): Promise<CiBuild[]> => {
+  public static getStartedBuilds = async (): Promise<CiBuild[]> => {
+    const realisticMaximumConcurrentBuilds = settings.maxConcurrentJobs * 10;
+
     const snapshot = await db
       .collection(CI_BUILDS_COLLECTION)
       .where('status', '==', 'started')
-      .limit(limit)
+      .limit(realisticMaximumConcurrentBuilds)
       .get();
 
     return snapshot.docs.map((doc) => doc.data() as CiBuild);

--- a/functions/src/service/discord.ts
+++ b/functions/src/service/discord.ts
@@ -10,7 +10,11 @@ export class Discord {
   public static async sendDebugLine(message: 'begin' | 'end') {
     const discord = await this.getInstance();
 
-    await discord.createMessage(settings.discord.channels.debug, `--- ${message} ---`);
+    try {
+      await discord.createMessage(settings.discord.channels.debug, `--- ${message} ---`);
+    } finally {
+      await this.disconnect();
+    }
   }
 
   public static async sendDebug(

--- a/functions/src/service/dockerhub.ts
+++ b/functions/src/service/dockerhub.ts
@@ -8,22 +8,31 @@ export class Dockerhub {
     return settings.dockerhub.host;
   }
 
-  private static getRepositoryName(imageType: ImageType) {
+  public static getRepositoryBaseName() {
+    return settings.dockerhub.repositoryBaseName;
+  }
+
+  public static getImageName(imageType: ImageType) {
+    const { baseImageName, hubImageName, editorImageName } = settings.dockerhub;
     switch (imageType) {
       case 'base':
-        return settings.dockerhub.baseRepository;
+        return `${baseImageName}`;
       case 'hub':
-        return settings.dockerhub.hubRepository;
+        return `${hubImageName}`;
       case 'editor':
-        return settings.dockerhub.editorRepository;
+        return `${editorImageName}`;
       default:
         throw new Error(`[Dockerhub] There is no repository configured of type ${imageType}.`);
     }
   }
 
+  public static getFullRepositoryName(imageType: ImageType) {
+    return `${this.getRepositoryBaseName()}/${this.getImageName(imageType)}`;
+  }
+
   public static async fetchImageData(imageType: ImageType, tag: string) {
     const { host } = this;
-    const repository = this.getRepositoryName(imageType);
+    const repository = this.getFullRepositoryName(imageType);
     const response = await fetch(`${host}/repositories/${repository}/tags/${tag}`);
 
     if (!response.ok) return null;


### PR DESCRIPTION
…erhub

#### Context

- Github runners run for 6 hours max.
- When they run out of disk space or memory they may stop showing logs or even stop entirely prematurely.
- When some of those timeouts happen, the workflows in [gameci/docker](https://github.com/game-ci/docker) repo will not report back
- In these latest changes we're reporting everything that versioning backend does to `#backend` channel on discord and recover from builds that have status "started" but are in fact already failed or succeeded.

#### Previous unreviews PRs

These two are part of the changes, but I merged them to check and update the deploy flow.
So they're still fine to be reviewed as part of code review.

- https://github.com/game-ci/versioning-backend/pull/32
- https://github.com/game-ci/versioning-backend/pull/33

#### Changes in this PR

- This is the first functional job for cleaner.
  - If an image never reported back after 6 hours, we mark the build as either failed or published, based on whether the docker image has the "most specific tag" assigned to it (which includes `baseOs` and the most specific `repositoryVersion`.

#### Other notes

- I've already put these changes live from my local, so everything works.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
