### PR TITLE
Discord anti anti

### DIFF
--- a/functions/src/cron/index.ts
+++ b/functions/src/cron/index.ts
@@ -1,4 +1,3 @@
-import { EventContext } from 'firebase-functions';
 import { firebase, functions } from '../service/firebase';
 import { Discord } from '../service/discord';
 import { ingestUnityVersions } from '../logic/ingestUnityVersions';
@@ -15,7 +14,7 @@ if (MINUTES < 10) {
 export const trigger = functions
   .runWith({ timeoutSeconds: 60, memory: '512MB' })
   .pubsub.schedule(`every ${MINUTES} minutes`)
-  .onRun(async (context: EventContext) => {
+  .onRun(async () => {
     try {
       await routineTasks();
     } catch (error) {
@@ -42,5 +41,6 @@ const routineTasks = async () => {
     await Discord.sendAlert(error);
   } finally {
     await Discord.sendDebugLine('end');
+    await Discord.disconnect();
   }
 };

--- a/functions/src/service/discord.ts
+++ b/functions/src/service/discord.ts
@@ -10,11 +10,7 @@ export class Discord {
   public static async sendDebugLine(message: 'begin' | 'end') {
     const discord = await this.getInstance();
 
-    try {
-      await discord.createMessage(settings.discord.channels.debug, `--- ${message} ---`);
-    } finally {
-      await this.disconnect();
-    }
+    await discord.createMessage(settings.discord.channels.debug, `--- ${message} ---`);
   }
 
   public static async sendDebug(
@@ -80,8 +76,6 @@ export class Discord {
       isSent = true;
     } catch (err) {
       firebase.logger.error('An error occurred while trying to send a message to discord.', err);
-    } finally {
-      await this.disconnect();
     }
 
     return isSent;
@@ -119,7 +113,7 @@ export class Discord {
     }
   }
 
-  static async disconnect(): Promise<void> {
+  public static async disconnect(): Promise<void> {
     if (!instance) return;
 
     instance.disconnect({ reconnect: false });


### PR DESCRIPTION
#### Context

This is how Discord deals with you after hitting a certain number of connections:

```
Hey Webber, It appears your bot, Unity CI, has connected to Discord more than 1000 times within a short time period. 
Since this kind of behaviour is usually the result of a bug we have gone ahead and reset your bot's token.
```

No warning or anything.

Since our bot is running on a cron, every 15 minutes, 24 hours a day.
This means the minimum number of connections is 100 a day.

The threshold of 1000 times seems to span multiple days.
This means our minimum number of connections is already very close to Discords maximum number of connections.

As a result we will not be able to set the cron to run much more frequently, as we'll hit the same problem even if we're only connecting at maximum once per run.

#### Changes

- Discord service class only connects as needed and never disconnects by itself.
- At the end of the cron in the finally block we disconnect from discord (required to be able to make new ones after a while)

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
