### PR TITLE
Windows base os support (part 2/2)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,9 +1,42 @@
 # Development
 
-Some keys are set as environment variables;
+## Setup
 
+Install firebase globally
 
-## Local Setup (optional)
+```bash
+npm i -g firebase-tools
+```
+
+Install dependencies
+
+```bash
+npm install
+```
+
+Run everything locally
+
+```bash
+firebase serve
+```
+
+## Deployment
+
+___Note:__ for this you will need access to the project._
+
+Login to your account
+
+```bash
+firebase login
+```
+
+Deploy everything
+
+```bash
+firebase deploy
+```
+
+## Additional local setup (optional)
 
 #### Credentials
 
@@ -74,9 +107,9 @@ If everything works, finally deploy the changes
 firebase deploy
 ```
 
-## New project setup 
+## Updating env/config variables 
 
-_(only when migrating to new firebase project / environment)_
+_Typically this is only needed when migrating to new firebase project or environment, or when security token needs to rotate._
 
 ```
 firebase functions:config:set discord.token="my_discord_token"

--- a/README.md
+++ b/README.md
@@ -1,39 +1,36 @@
-# Unity CI Versioning Backend
+# GameCI Versioning Backend
 
+## Unity version ingest
 
-## Development
+TODO - Describe how it works
 
-Install firebase globally
+## game-ci/docker version ingest
 
-```bash
-npm i -g firebase-tools
+TODO - Describe how it works
+
+## Scheduler
+
+Each CiJob starts its own workflow.
+
+Each Workflow generates multiple CiBuilds: one per baseOs-targetPlatform combination.
+The CiJob workflow will report back a CiBuild for each combination.
+
+For example:
+
+```text
+...
+  ubuntu-<version>-linuxIl2cpp
+  ubuntu-<version>-webgl
+  windows-<version>-webgl
+...
 ```
 
-Install dependencies
+An endpoint from this backend will listen to the reports and update the database.
+Each CiBuild starts with the status "started" after it is being reported.
 
-```bash
-npm install
-```
+When the last CiBuild is set to "published", the CiJob for that version is also set to "completed".
+Completed CiJobs are reported to Discord.
 
-Run everything locally
+## Ingeminator
 
-```bash
-firebase serve
-```
-
-## Deployment
-
-___Note:__ for this you will need access to the project._
-
-Login to your account
-
-```bash
-firebase login
-```
-
-Deploy everything 
-
-```bash
-firebase deploy
-```
-
+TODO - Describe how it works

--- a/functions/src/api/reportNewBuild.ts
+++ b/functions/src/api/reportNewBuild.ts
@@ -7,7 +7,7 @@ import { CiJobs } from '../model/ciJobs';
 import { Discord } from '../service/discord';
 import { EditorVersionInfo } from '../model/editorVersionInfo';
 import { RepoVersionInfo } from '../model/repoVersionInfo';
-import { ImageType } from '../model/image';
+import { Image, ImageType } from '../model/image';
 
 export const reportNewBuild = functions.https.onRequest(async (req: Request, res: Response) => {
   try {
@@ -58,7 +58,7 @@ const createDryRunJob = async (jobId: string, imageType: ImageType, editorVersio
   firebase.logger.debug('running dryrun for image', imageType, editorVersion);
   const repoVersionInfo = await RepoVersionInfo.getLatest();
 
-  if (imageType === 'editor') {
+  if (imageType === Image.types.editor) {
     const editorVersionInfo = await EditorVersionInfo.get(editorVersion);
     await CiJobs.create(jobId, imageType, repoVersionInfo, editorVersionInfo);
   } else {

--- a/functions/src/api/reportNewBuild.ts
+++ b/functions/src/api/reportNewBuild.ts
@@ -2,11 +2,12 @@ import { firebase, functions } from '../service/firebase';
 import { Request } from 'firebase-functions/lib/providers/https';
 import { Response } from 'express-serve-static-core';
 import { Token } from '../config/token';
-import { BuildInfo, CiBuilds, ImageType } from '../model/ciBuilds';
+import { BuildInfo, CiBuilds } from '../model/ciBuilds';
 import { CiJobs } from '../model/ciJobs';
 import { Discord } from '../service/discord';
 import { EditorVersionInfo } from '../model/editorVersionInfo';
 import { RepoVersionInfo } from '../model/repoVersionInfo';
+import { ImageType } from '../model/image';
 
 export const reportNewBuild = functions.https.onRequest(async (req: Request, res: Response) => {
   try {

--- a/functions/src/api/reportPublication.ts
+++ b/functions/src/api/reportPublication.ts
@@ -5,6 +5,7 @@ import { Token } from '../config/token';
 import { CiBuilds } from '../model/ciBuilds';
 import { CiJobs } from '../model/ciJobs';
 import { Discord } from '../service/discord';
+import { Image } from '../model/image';
 
 export const reportPublication = functions.https.onRequest(async (req: Request, res: Response) => {
   try {
@@ -22,8 +23,8 @@ export const reportPublication = functions.https.onRequest(async (req: Request, 
     const parentJobIsNowCompleted = await CiBuilds.markBuildAsPublished(buildId, jobId, dockerInfo);
     if (parentJobIsNowCompleted) {
       // Report new publications as news
-      let message = '';
-      if (dockerInfo.imageName === 'editor') {
+      let message;
+      if (dockerInfo.imageName === Image.types.editor) {
         // i.e. [editor-2017.1.0f3-0.5.0]
         const [imageType, publicationName, version] = jobId.split('-');
         // i.e. [v0.5.0] images for [editor] [2020.2.22f2]

--- a/functions/src/logic/buildQueue/ingeminator.ts
+++ b/functions/src/logic/buildQueue/ingeminator.ts
@@ -9,6 +9,7 @@ import { Scheduler } from './scheduler';
 import admin from 'firebase-admin';
 import Timestamp = admin.firestore.Timestamp;
 import { settings } from '../../config/settings';
+import { GitHubWorkflow } from '../../model/gitHubWorkflow';
 
 export class Ingeminator {
   numberToSchedule: number;
@@ -122,7 +123,7 @@ export class Ingeminator {
     const response = await this.gitHubClient.repos.createDispatchEvent({
       owner: 'unity-ci',
       repo: 'docker',
-      event_type: 'retry_ubuntu_editor_image_requested',
+      event_type: GitHubWorkflow.getEventTypeForRetryingEditorCiBuild(baseOs),
       client_payload: {
         jobId,
         buildId,

--- a/functions/src/logic/buildQueue/ingeminator.ts
+++ b/functions/src/logic/buildQueue/ingeminator.ts
@@ -10,6 +10,7 @@ import admin from 'firebase-admin';
 import Timestamp = admin.firestore.Timestamp;
 import { settings } from '../../config/settings';
 import { GitHubWorkflow } from '../../model/gitHubWorkflow';
+import { Image } from '../../model/image';
 
 export class Ingeminator {
   numberToSchedule: number;
@@ -30,7 +31,7 @@ export class Ingeminator {
     }
 
     for (const job of jobs) {
-      if (job.data.imageType !== 'editor') {
+      if (job.data.imageType !== Image.types.editor) {
         throw new Error(
           '[Ingeminator] Did not expect to be handling non-editor image type rescheduling.',
         );

--- a/functions/src/logic/buildQueue/scheduler.ts
+++ b/functions/src/logic/buildQueue/scheduler.ts
@@ -128,7 +128,6 @@ export class Scheduler {
       throw new Error('[Scheduler] Expected hub job to be present');
     }
 
-    // Todo - handle logic for multiple baseOses
     // Schedule it
     if (['created', 'failed'].includes(job.status)) {
       const { repoVersionFull, repoVersionMinor, repoVersionMajor } = this;

--- a/functions/src/logic/buildQueue/scheduler.ts
+++ b/functions/src/logic/buildQueue/scheduler.ts
@@ -9,6 +9,7 @@ import { EditorVersionInfo } from '../../model/editorVersionInfo';
 import { Discord } from '../../service/discord';
 import { Ingeminator } from './ingeminator';
 import { GitHubWorkflow } from '../../model/gitHubWorkflow';
+import { Image } from '../../model/image';
 
 export class Scheduler {
   private repoVersion: string;
@@ -80,13 +81,12 @@ export class Scheduler {
 
   async ensureThatBaseImageHasBeenBuilt(): Promise<boolean> {
     // Get base image information
-    const jobId = CiJobs.parseJobId('base', this.repoVersion);
+    const jobId = CiJobs.parseJobId(Image.types.base, this.repoVersion);
     const job = await CiJobs.get(jobId);
     if (job === null) {
       throw new Error('[Scheduler] Expected base job to be present');
     }
 
-    // Todo - handle logic for multiple baseOses
     // Schedule it
     if (['created', 'failed'].includes(job.status)) {
       const { repoVersionFull, repoVersionMinor, repoVersionMajor } = this;
@@ -122,7 +122,7 @@ export class Scheduler {
 
   async ensureThatHubImageHasBeenBuilt(): Promise<boolean> {
     // Get hub image information
-    const jobId = CiJobs.parseJobId('hub', this.repoVersion);
+    const jobId = CiJobs.parseJobId(Image.types.hub, this.repoVersion);
     const job = await CiJobs.get(jobId);
     if (job === null) {
       throw new Error('[Scheduler] Expected hub job to be present');

--- a/functions/src/model-triggers/editorVersionInfo.ts
+++ b/functions/src/model-triggers/editorVersionInfo.ts
@@ -1,4 +1,3 @@
-import { EventContext } from 'firebase-functions';
 import { QueryDocumentSnapshot } from 'firebase-functions/lib/providers/firestore';
 import { firebase, functions } from '../service/firebase';
 
@@ -6,16 +5,15 @@ import { EditorVersionInfo } from '../model/editorVersionInfo';
 import { CiJobs } from '../model/ciJobs';
 import { RepoVersionInfo } from '../model/repoVersionInfo';
 import { Discord } from '../service/discord';
-
-const imageType = 'editor';
+import { Image } from '../model/image';
 
 export const onCreate = functions.firestore
   .document(`${EditorVersionInfo.collection}/{itemId}`)
-  .onCreate(async (snapshot: QueryDocumentSnapshot, context: EventContext) => {
+  .onCreate(async (snapshot: QueryDocumentSnapshot) => {
     const editorVersionInfo = snapshot.data() as EditorVersionInfo;
     const repoVersionInfo = await RepoVersionInfo.getLatest();
 
-    const jobId = CiJobs.generateJobId(imageType, repoVersionInfo, editorVersionInfo);
+    const jobId = CiJobs.generateJobId(Image.types.editor, repoVersionInfo, editorVersionInfo);
     if (await CiJobs.exists(jobId)) {
       const message = `Skipped creating CiJob for new editorVersion (${editorVersionInfo.version}).`;
       firebase.logger.warn(message);
@@ -23,6 +21,6 @@ export const onCreate = functions.firestore
       return;
     }
 
-    await CiJobs.create(jobId, imageType, repoVersionInfo, editorVersionInfo);
+    await CiJobs.create(jobId, Image.types.editor, repoVersionInfo, editorVersionInfo);
     firebase.logger.info(`CiJob created: ${jobId}`);
   });

--- a/functions/src/model-triggers/repoVersionInfo.ts
+++ b/functions/src/model-triggers/repoVersionInfo.ts
@@ -1,4 +1,3 @@
-import { EventContext } from 'firebase-functions';
 import { QueryDocumentSnapshot } from 'firebase-functions/lib/providers/firestore';
 import { db, firebase, functions } from '../service/firebase';
 
@@ -8,10 +7,11 @@ import { EditorVersionInfo } from '../model/editorVersionInfo';
 import semver from 'semver/preload';
 import { Discord } from '../service/discord';
 import { chunk } from 'lodash';
+import { Image } from '../model/image';
 
 export const onCreate = functions.firestore
   .document(`${RepoVersionInfo.collection}/{itemId}`)
-  .onCreate(async (snapshot: QueryDocumentSnapshot, context: EventContext) => {
+  .onCreate(async (snapshot: QueryDocumentSnapshot) => {
     const repoVersionInfo = snapshot.data() as RepoVersionInfo;
     const currentRepoVersion = repoVersionInfo.version;
     const latestRepoVersionInfo = await RepoVersionInfo.getLatest();
@@ -63,7 +63,7 @@ export const onCreate = functions.firestore
     // But now `create` seems to also be supported in batch calls
     const editorVersionInfoChunks: EditorVersionInfo[][] = chunk(editorVersionInfos, 20);
     for (const editorVersionInfoChunk of editorVersionInfoChunks) {
-      const imageType = 'editor';
+      const imageType = Image.types.editor;
       const batch = db.batch();
       for (const editorVersionInfo of editorVersionInfoChunk) {
         const editorJobId = CiJobs.generateJobId(imageType, repoVersionInfo, editorVersionInfo);

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -1,15 +1,15 @@
-import { db, admin, firebase } from '../service/firebase';
-import Timestamp = admin.firestore.Timestamp;
-import FieldValue = admin.firestore.FieldValue;
+import { admin, db, firebase } from '../service/firebase';
 import { settings } from '../config/settings';
 import { CiJobs } from './ciJobs';
+import { BaseOs, ImageType } from './image';
+import Timestamp = admin.firestore.Timestamp;
+import FieldValue = admin.firestore.FieldValue;
 
 export type BuildStatus = 'started' | 'failed' | 'published';
-export type ImageType = 'base' | 'hub' | 'editor';
 
 // Used in Start API
 export interface BuildInfo {
-  baseOs: string;
+  baseOs: BaseOs;
   repoVersion: string;
   editorVersion: string;
   targetPlatform: string;

--- a/functions/src/model/ciJobs.ts
+++ b/functions/src/model/ciJobs.ts
@@ -6,7 +6,7 @@ import { RepoVersionInfo } from './repoVersionInfo';
 import DocumentSnapshot = admin.firestore.DocumentSnapshot;
 import { chunk } from 'lodash';
 import { settings } from '../config/settings';
-import { ImageType } from './image';
+import { Image, ImageType } from './image';
 
 export type JobStatus =
   | 'created'
@@ -282,7 +282,7 @@ export class CiJobs {
     editorVersionInfo: EditorVersionInfo | null = null,
   ) {
     const { version: repoVersion } = repoVersionInfo;
-    if (imageType !== 'editor') {
+    if (imageType !== Image.types.editor) {
       return CiJobs.parseJobId(imageType, repoVersion);
     }
 
@@ -299,7 +299,7 @@ export class CiJobs {
     repoVersion: string,
     editorVersion: string | null = null,
   ) {
-    if (imageType !== 'editor') {
+    if (imageType !== Image.types.editor) {
       return `${imageType}-${repoVersion}`;
     }
 

--- a/functions/src/model/ciJobs.ts
+++ b/functions/src/model/ciJobs.ts
@@ -3,10 +3,10 @@ import { EditorVersionInfo } from './editorVersionInfo';
 import FieldValue = admin.firestore.FieldValue;
 import Timestamp = admin.firestore.Timestamp;
 import { RepoVersionInfo } from './repoVersionInfo';
-import { ImageType } from './ciBuilds';
 import DocumentSnapshot = admin.firestore.DocumentSnapshot;
 import { chunk } from 'lodash';
 import { settings } from '../config/settings';
+import { ImageType } from './image';
 
 export type JobStatus =
   | 'created'

--- a/functions/src/model/gitHubWorkflow.ts
+++ b/functions/src/model/gitHubWorkflow.ts
@@ -1,0 +1,58 @@
+import { BaseOs } from './image';
+import { EditorVersionInfo } from './editorVersionInfo';
+
+export type GitHubEventType =
+  | 'new_base_images_requested'
+  | 'new_hub_images_requested'
+  | 'new_legacy_editor_image_requested'
+  | 'new_post_2019_2_editor_image_requested'
+  | 'retry_ubuntu_editor_image_requested'
+  | 'retry_windows_editor_image_requested';
+
+export type FriendlyEventTypes =
+  | 'newBaseImages'
+  | 'newHubImages'
+  | 'newLegacyImage'
+  | 'newPost2019dot2Image'
+  | 'retryUbuntuImage'
+  | 'retryWindowsImage';
+
+export class GitHubWorkflow {
+  public static get eventTypes(): Record<FriendlyEventTypes, GitHubEventType> {
+    return {
+      newBaseImages: 'new_base_images_requested',
+      newHubImages: 'new_hub_images_requested',
+      newLegacyImage: 'new_legacy_editor_image_requested',
+      newPost2019dot2Image: 'new_post_2019_2_editor_image_requested',
+      retryUbuntuImage: 'retry_ubuntu_editor_image_requested',
+      retryWindowsImage: 'retry_windows_editor_image_requested',
+    };
+  }
+
+  /**
+   * Note: CiJob includes all builds for all base OSes
+   */
+  public static getEventTypeForEditorCiJob(editorVersionInfo: EditorVersionInfo): GitHubEventType {
+    const { major, minor } = editorVersionInfo;
+
+    if (major >= 2020 || (major === 2019 && minor >= 3)) {
+      return GitHubWorkflow.eventTypes.newPost2019dot2Image;
+    } else {
+      return GitHubWorkflow.eventTypes.newLegacyImage;
+    }
+  }
+
+  /**
+   * Note: CiBuild includes only a single baseOs-editorVersion-targetPlatform combination.
+   */
+  public static getEventTypeForRetryingEditorCiBuild(baseOs: BaseOs): GitHubEventType {
+    switch (baseOs) {
+      case 'ubuntu':
+        return GitHubWorkflow.eventTypes.retryUbuntuImage;
+      case 'windows':
+        return GitHubWorkflow.eventTypes.retryWindowsImage;
+      default:
+        throw new Error(`No retry method for base OS "${baseOs}" implemented.`);
+    }
+  }
+}

--- a/functions/src/service/dockerhub.ts
+++ b/functions/src/service/dockerhub.ts
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import { settings } from '../config/settings';
+import { Image } from '../model/image';
 
 type ImageType = 'base' | 'hub' | 'editor';
 
@@ -15,11 +16,11 @@ export class Dockerhub {
   public static getImageName(imageType: ImageType) {
     const { baseImageName, hubImageName, editorImageName } = settings.dockerhub;
     switch (imageType) {
-      case 'base':
+      case Image.types.base:
         return `${baseImageName}`;
-      case 'hub':
+      case Image.types.hub:
         return `${hubImageName}`;
-      case 'editor':
+      case Image.types.editor:
         return `${editorImageName}`;
       default:
         throw new Error(`[Dockerhub] There is no repository configured of type ${imageType}.`);

--- a/functions/src/service/dockerhub.ts
+++ b/functions/src/service/dockerhub.ts
@@ -1,8 +1,6 @@
 import fetch from 'node-fetch';
 import { settings } from '../config/settings';
-import { Image } from '../model/image';
-
-type ImageType = 'base' | 'hub' | 'editor';
+import { Image, ImageType } from '../model/image';
 
 export class Dockerhub {
   private static get host() {


### PR DESCRIPTION
#### Changes

- Follow-up from #36 
- Adds triggers that will not only build ubuntu images but also windows images
- Retry mechanism will also work for both types of images.

Decided to keep a single queue, so if either Windows or Ubuntu images are broken, all images will stop building.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
