### PR TITLE
fix: scraper of unity versions

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,7 @@
     "test": "echo \"No tests yet, feel free to add\" && exit 0"
   },
   "engines": {
-    "node": "10"
+    "node": "12"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
+++ b/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
@@ -1,7 +1,7 @@
 import { getDocumentFromUrl } from '../utils/get-document-from-url';
 import { EditorVersionInfo } from '../../model/editorVersionInfo';
 
-const UNITY_ARCHIVE_URL = 'https://unity3d.com/get-unity/download/archive';
+const UNITY_ARCHIVE_URL = 'https://unity.com/releases/editor/archive';
 
 /**
  * Based on https://github.com/BLaZeKiLL/unity-scraper
@@ -9,7 +9,7 @@ const UNITY_ARCHIVE_URL = 'https://unity3d.com/get-unity/download/archive';
 export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
   const document = await getDocumentFromUrl(UNITY_ARCHIVE_URL);
 
-  const links = Array.from(document.querySelectorAll('a.unityhub[href]'));
+  const links = Array.from(document.querySelectorAll('.release-links div:first-child a[href]'));
   const hrefs = links.map((a) => a.getAttribute('href')) as string[];
 
   const versionInfoList = hrefs.map((href) => {


### PR DESCRIPTION
#### Changes

- Fix selector and correct url for scraping Unity Editor versions.
- Fixes https://github.com/game-ci/docker/issues/193 (although, note that 2020.2.x might not be compatible with our current setup yet, as requirements changed.)

#### How to test:

Go to Unity Editor [archive page](https://unity.com/releases/editor/archive) and run this in your console: 
```ts
document.querySelectorAll('.release-links div:first-child a[href]').forEach(link => console.log(link.href))
```

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
