### PR TITLE
Fix unity versions scrapping not getting all the versions

### DIFF
--- a/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
+++ b/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
@@ -9,12 +9,13 @@ export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
 
   const scripts = document.querySelectorAll('script');
 
+  const allVersions = new Map<string, EditorVersionInfo>();
+
   for (const script of scripts) {
     if (script.textContent) {
       const matches = [...script.textContent.matchAll(unity_version_regex)];
       if (matches.length > 0) {
-        const uniqueVersions = new Set<string>();
-        return matches
+        const versions = matches
           .filter((match) => {
             // Filter out prerelease and unsupported versions
             const [_, major, minor, patch, changeSet] = match;
@@ -23,8 +24,7 @@ export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
           .map((match) => {
             const [_, major, minor, patch, changeSet] = match;
             const version = `${major}.${minor}.${patch}`;
-            if (!uniqueVersions.has(version)) {
-              uniqueVersions.add(version);
+            if (!allVersions.has(version)) {
               return {
                 version,
                 changeSet,
@@ -38,8 +38,16 @@ export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
             return null;
           })
           .filter((version) => version !== null) as EditorVersionInfo[];
+
+        versions.forEach((it) => {
+          allVersions.set(it.version, it);
+        });
       }
     }
+  }
+
+  if (allVersions.size > 0) {
+    return Array.from(allVersions.values());
   }
 
   throw new Error('No Unity versions found!');


### PR DESCRIPTION
#### Changes

This pull request is fixing the unity versions scrapping.

The previous implementation was not returning all the versions anymore. The loop was stopping on the first non empty script tag containing at least one version. But currently it does not work.

The proposed fix is to loop on all the scripts tag, store all the versions in a map and returns them at the end.

It will probably fix the following issues: https://github.com/game-ci/docker/issues/251, https://github.com/game-ci/docker/issues/250

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
