### PR TITLE
Bump unity-changeset version

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.17.21",
     "node-fetch": "^2.7.0",
     "semver": "^7.6.3",
-    "unity-changeset": "^2.3.0"
+    "unity-changeset": "^2.5.0"
   },
   "devDependencies": {
     "@octokit/types": "^13.5.0",

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -4857,10 +4857,10 @@ undici-types@~6.19.8:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
-unity-changeset@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/unity-changeset/-/unity-changeset-2.3.0.tgz#78f519d505ef969400f418494e904c7274745c78"
-  integrity sha512-VnpEmFLbTgkbjW9ypJRbuWPs3ML0WGt+aaDPjQWPD7oaKWgNS6rKsvehEKEuxbkGuDLvwbrHscVqK0bQH+0kgA==
+unity-changeset@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/unity-changeset/-/unity-changeset-2.5.0.tgz#870203ff37ba4dddbde9a3000c5863f25b527169"
+  integrity sha512-+j4+j9okJbvM3RDBkbXHqGErLDbtWYwL3zEbjdgC0XoMcDYfrep2IJXFXkwYUYl8U/F9cCL69WRZnMuAE2YUWw==
   dependencies:
     "@deno/shim-deno" "~0.18.0"
     graphql-request "6.1.0"


### PR DESCRIPTION
update version for get unity supported versions

Currently the unity 6000.1.0f1 are missing

#### Changes

-  Updating only `unity-changeset` version to get new Unity 6000.x versions from supported stream (6000.1, 6000.2, ...)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the "unity-changeset" dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->