### PR TITLE
feat: support xlts versions (enterprise images)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,3 @@
 nodeLinker: node-modules
+
+npmRegistryServer: "https://registry.npmjs.org/"

--- a/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
+++ b/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
@@ -5,6 +5,15 @@ const unity_version_regex = /^(\d+)\.(\d+)\.(\d+)([a-zA-Z]+)(-?\d+)$/;
 
 export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
   const unityVersions = await searchChangesets(SearchMode.Default);
+  const unityXltsVersions = await searchChangesets(SearchMode.XLTS);
+
+  // Merge XLTS versions into main list, avoiding duplicates
+  const existingVersions = new Set(unityVersions.map((v) => v.version));
+  for (const xltsVersion of unityXltsVersions) {
+    if (!existingVersions.has(xltsVersion.version)) {
+      unityVersions.push(xltsVersion);
+    }
+  }
 
   if (unityVersions?.length > 0) {
     return unityVersions


### PR DESCRIPTION
## Rationale

Using the following commands to find out how many images are XLTS and not already in the list of regularly supported images.

```bash
# Get clean lists (no alpha/beta/rc)
npx unity-changeset list --all  | sort -u > all.sorted
npx unity-changeset list --xlts | sort -u > xlts.sorted

# Only in XLTS (new to ingest)
comm -13 all.sorted xlts.sorted 
```

Amount of images that are XLTS = 19

```
comm -13 all.sorted xlts.sorted | wc -l # output: 19
```

There are 19 images in XLTS which is already to ingest in our build pipelines.

## Risks

There is however a risk that these editor versions are somehow different and will not succeed to build. They may block the entire build pipeline also for other images.

To mitigate this risk we'll manually monitor the 19 images and see if they fail or not.

## What if they do fail?

In https://console.firebase.google.com/u/0/project/unity-ci-versions/firestore/databases/-default-/data we'll set the `CiJobs` to `deprecated` and their build tasks called `CiBuilds` to `failed`, and revert this PR.

## Changes

- Adds build support for XLTS images
- Fixes: https://github.com/game-ci/unity-builder/issues/744
- Fixes: https://github.com/game-ci/documentation/issues/510

## Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unity version catalog now includes XLTS releases alongside existing versions.
  * Duplicate versions are automatically de-duplicated to keep the list clean.
  * Existing validation and filtering of version formats remain in place for consistency.

* **Chores**
  * Updated package manager registry configuration to use the official npm registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->