### PR TITLE
Deprecate Unity Editor versions 2021 and older

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The backend regularly scrapes Unity version information:
 2. Filters versions (only stable versions 2017+)
 3. Stores version details in Firestore
 4. Notifies maintainers via Discord
-5. Schedules build jobs for new/non-deprecated versions (2021+)
+5. Schedules build jobs for new/non-deprecated versions (2022+)
 
 ## CI Job Workflow
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The backend regularly scrapes Unity version information:
 2. Filters versions (only stable versions 2017+)
 3. Stores version details in Firestore
 4. Notifies maintainers via Discord
-5. Schedules build jobs for new versions
+5. Schedules build jobs for new/non-deprecated versions (2021+)
 
 ## CI Job Workflow
 

--- a/functions/src/model/ciJobs.ts
+++ b/functions/src/model/ciJobs.ts
@@ -143,7 +143,7 @@ export class CiJobs {
     editorVersionInfo: EditorVersionInfo | null = null,
   ): CiJob => {
     let status: JobStatus = 'deprecated';
-    if (editorVersionInfo === null || editorVersionInfo.major >= 2021) {
+    if (editorVersionInfo === null || editorVersionInfo.major >= 2022) {
       status = 'created';
     }
 

--- a/functions/src/model/ciJobs.ts
+++ b/functions/src/model/ciJobs.ts
@@ -143,11 +143,7 @@ export class CiJobs {
     editorVersionInfo: EditorVersionInfo | null = null,
   ): CiJob => {
     let status: JobStatus = 'deprecated';
-    if (
-      editorVersionInfo === null ||
-      editorVersionInfo.major >= 2019 ||
-      (editorVersionInfo.major === 2018 && editorVersionInfo.minor >= 2)
-    ) {
+    if (editorVersionInfo === null || editorVersionInfo.major >= 2021) {
       status = 'created';
     }
 


### PR DESCRIPTION
#### Changes

- Deprecate Unity Editor versions 2021 and older

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow to schedule build jobs only for new/non-deprecated Unity versions (2022+).

* **Chores**
  * Tightened editor-version eligibility so build jobs are created only for null or Unity 2022 and newer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->