### PR TITLE
Attempt to prevent duplicate workflow dispatch by marking jobs in progress at build start

### DIFF
--- a/functions/src/model/ciJobs.ts
+++ b/functions/src/model/ciJobs.ts
@@ -205,7 +205,7 @@ export class CiJobs {
 
     // Do not override failure or completed
     let { status } = currentBuild;
-    if (['scheduled'].includes(status)) {
+    if (['created', 'scheduled'].includes(status)) {
       status = 'inProgress';
     }
 


### PR DESCRIPTION
#### What problem this fixes
We’ve seen `reportNewBuild` fail with: **`A build with "<buildId>" as identifier already exists`**. That happens when the same workflow/build gets started twice, creating duplicate build reports for the same `buildId`.

#### Why it can happen
Right now, the scheduler:
- **Dispatches the GitHub Actions workflow first**, then
- **Updates Firestore** to move the job from `created -> scheduled`

Because dispatch is an external side-effect, there’s a small window where:
- GitHub has accepted the dispatch (workflow may already be running), but
- The job can still be `created` in Firestore (if we crash/time out before the update)

Since the scheduler only picks jobs with `status == "created"`, that job can be dispatched again later.

#### What this change does
When a workflow starts, it calls `reportNewBuild`, which marks the job as in progress.
This PR makes that “build started” signal authoritative by allowing:

- **`created -> inProgress`** (in addition to `scheduled -> inProgress`)

So even if the scheduler never wrote `created -> scheduled`, the job still moves out of the schedulable state as soon as the workflow reports it started.

#### Why this is safe
- **Does not override** terminal states like `failed` or `completed`.
- **Does not change** the duplicate-build protection: duplicate `buildId` reports still fail as before.
- It only closes the gap where a running workflow could leave its job marked `created`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CI job state transitions to allow jobs in the created state to progress to in-progress status, in addition to jobs in the scheduled state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->