### PR TITLE
fix: add circuit breakers to prevent re-queue infinite retry loop

### DIFF
--- a/functions/src/logic/buildQueue/scheduler.ts
+++ b/functions/src/logic/buildQueue/scheduler.ts
@@ -85,6 +85,16 @@ export class Scheduler {
 
     // Schedule it
     if (['created', 'failed'].includes(job.status)) {
+      // Check retry limit before re-dispatching
+      if (CiJobs.hasExceededRetryLimit(job, settings.maxFailuresPerBuild)) {
+        const message =
+          `[Scheduler] Base image job ${jobId} has exceeded the maximum retry limit ` +
+          `(${settings.maxFailuresPerBuild}). Manual action is required.`;
+        logger.warn(message);
+        await Discord.sendAlert(message);
+        return false;
+      }
+
       const { repoVersionFull, repoVersionMinor, repoVersionMajor } = this;
       const response = await this.gitHub.repos.createDispatchEvent({
         owner: 'unity-ci',
@@ -126,6 +136,16 @@ export class Scheduler {
 
     // Schedule it
     if (['created', 'failed'].includes(job.status)) {
+      // Check retry limit before re-dispatching
+      if (CiJobs.hasExceededRetryLimit(job, settings.maxFailuresPerBuild)) {
+        const message =
+          `[Scheduler] Hub image job ${jobId} has exceeded the maximum retry limit ` +
+          `(${settings.maxFailuresPerBuild}). Manual action is required.`;
+        logger.warn(message);
+        await Discord.sendAlert(message);
+        return false;
+      }
+
       const { repoVersionFull, repoVersionMinor, repoVersionMajor } = this;
       const response = await this.gitHub.repos.createDispatchEvent({
         owner: 'unity-ci',

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -135,14 +135,33 @@ export class CiBuilds {
 
     let result;
     if (snapshot.exists) {
-      // Builds can be retried after a failure.
-      if (snapshot.data()?.status === 'failed') {
-        // In case or reporting a new build during retry step, only overwrite these fields
+      const existingStatus = snapshot.data()?.status;
+      if (existingStatus === 'failed') {
+        // Builds can be retried after a failure.
+        // In case of reporting a new build during retry step, only overwrite these fields
         result = await ref.set(data, {
           mergeFields: ['status', 'meta.lastBuildStart', 'modifiedDate'],
         });
+      } else if (existingStatus === 'started') {
+        const existingJobId = snapshot.data()?.relatedJobId;
+        if (existingJobId !== relatedJobId) {
+          // Different job trying to register same build - this is unexpected and should fail
+          throw new Error(
+            `Build "${buildId}" already exists with jobId "${existingJobId}", ` +
+              `but received conflicting request from jobId "${relatedJobId}"`,
+          );
+        }
+        // Idempotent - same job retrying after network timeout, safe to skip
+        logger.info(`Build "${buildId}" already exists with status "started", skipping`);
+        return;
+      } else if (existingStatus === 'published') {
+        // Build is already done, nothing to do
+        logger.info(`Build "${buildId}" already published, skipping`);
+        return;
       } else {
-        throw new Error(`A build with "${buildId}" as identifier already exists`);
+        throw new Error(
+          `A build with "${buildId}" already exists with status "${existingStatus}"`,
+        );
       }
     } else {
       result = await ref.create(data);

--- a/functions/src/model/ciJobs.ts
+++ b/functions/src/model/ciJobs.ts
@@ -205,7 +205,7 @@ export class CiJobs {
 
     // Do not override failure or completed
     let { status } = currentBuild;
-    if (['scheduled'].includes(status)) {
+    if (['created', 'scheduled'].includes(status)) {
       status = 'inProgress';
     }
 
@@ -225,6 +225,10 @@ export class CiJobs {
       'meta.lastBuildFailure': Timestamp.now(),
       modifiedDate: Timestamp.now(),
     });
+  };
+
+  static hasExceededRetryLimit = (job: CiJob, maxRetries: number): boolean => {
+    return job.meta.failureCount >= maxRetries;
   };
 
   static markJobAsCompleted = async (jobId: string) => {


### PR DESCRIPTION
## Summary

Three targeted fixes that close the race windows causing cascading job failures and infinite re-dispatch loops in the build queue scheduler. These changes are minimal and surgical -- each addresses a specific failure mode that has been observed in production.

- **Make `registerNewBuild` idempotent** so that network-timeout retries of the "started" report no longer throw, preventing the cascading failure that marks jobs as failed and halts the scheduler when `failingJobs.length > maxToleratedFailures`
- **Add retry limits to base/hub image dispatch** so the scheduler stops re-dispatching workflows every 15-minute cron cycle when a base or hub job is stuck in "created" or "failed" state (editor images already had this protection via the Ingeminator)
- **Allow `created` -> `inProgress` job transition** so a workflow's `reportNewBuild` call moves the job out of the schedulable state even if the scheduler crashed before writing `created` -> `scheduled`, preventing duplicate dispatch

## Detailed Changes

### Fix 1: Idempotent `registerNewBuild` (`functions/src/model/ciBuilds.ts`)

**Problem:** When a GitHub Actions workflow calls `reportNewBuild` with `status: started` but the HTTP response is lost (network timeout, Firebase cold start), the action's error handler calls `reportBuildFailure`, marking the job as failed. The next cron cycle retries the workflow, which calls `reportNewBuild` again -- but now the build already exists with status "started", so it throws `"A build with X as identifier already exists"`, causing another failure report, ad infinitum.

**Fix:**
- If build exists with status `"started"` and **same jobId**: silently return (idempotent retry)
- If build exists with status `"started"` and **different jobId**: throw with descriptive error (indicates a real bug)
- If build exists with status `"published"`: silently return (build already completed)
- If build exists with status `"failed"`: overwrite with new `"started"` (existing behavior, preserved)

This is essentially what #73 proposed.

### Fix 2: Retry limits for base/hub image dispatch (`functions/src/logic/buildQueue/scheduler.ts`, `functions/src/model/ciJobs.ts`)

**Problem:** `ensureThatBaseImageHasBeenBuilt()` and `ensureThatHubImageHasBeenBuilt()` re-dispatch GitHub workflows on every cron cycle (every 15 minutes) when the job is in "created" or "failed" state, with **no backoff and no retry limit**. Editor images are protected by the Ingeminator's `maxFailuresPerBuild` check, but base/hub images have no such protection.

**Fix:**
- Added `CiJobs.hasExceededRetryLimit()` helper that checks `job.meta.failureCount >= maxRetries`
- Both `ensureThatBaseImageHasBeenBuilt()` and `ensureThatHubImageHasBeenBuilt()` now check this limit (using the existing `settings.maxFailuresPerBuild` = 15) before dispatching
- When the limit is reached, logs a warning and sends a Discord alert asking for manual intervention

### Fix 3: Allow `created` -> `inProgress` transition (`functions/src/model/ciJobs.ts`)

**Problem:** The scheduler dispatches a GitHub workflow first, then updates Firestore (`created` -> `scheduled`). If the scheduler crashes between these two steps, the job stays `created` even though a workflow is running. The next cron cycle picks it up again and dispatches a duplicate workflow.

When that workflow calls `reportNewBuild`, `markJobAsInProgress` only accepts `"scheduled"` status, so the job stays `"created"` -- leaving it eligible for yet another duplicate dispatch.

**Fix:** `markJobAsInProgress` now accepts both `"created"` and `"scheduled"` statuses, so the workflow's report moves the job out of the schedulable state regardless of whether the scheduler's `markJobAsScheduled` call succeeded.

This is essentially what #74 proposed.

## Related

- Incorporates the approach from #73 (make registerNewBuild idempotent)
- Incorporates the approach from #74 (allow created -> inProgress transition)
- Root cause analysis: https://github.com/game-ci/docker/pull/273

## Test plan

- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit` passes with zero errors)
- [ ] Review each change against the existing Firestore state machine to confirm no unintended state transitions
- [ ] Verify the `maxFailuresPerBuild` setting (15) is appropriate for base/hub images
- [ ] Consider deploying to a staging Firebase project and simulating the failure scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented automatic retry limit enforcement to prevent indefinite job re-dispatch attempts.
  * Added Discord notifications when builds exceed configured retry limits.
  * Enhanced concurrent build registration with improved conflict detection and idempotent retry handling.
  * Improved job status transition logic for more reliable lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->