### PR TITLE
Fix manual cleanup skipping builds with publishedDate

### DIFF
--- a/functions/src/logic/buildQueue/cleaner.ts
+++ b/functions/src/logic/buildQueue/cleaner.ts
@@ -30,22 +30,20 @@ export class Cleaner {
     results.push(`Found ${startedBuilds.length} build(s) with status "started".`);
 
     for (const startedBuild of startedBuilds) {
-      const { buildId, meta, relatedJobId: jobId, imageType, buildInfo } = startedBuild;
-      const { publishedDate } = meta;
+      const { buildId, relatedJobId: jobId, imageType, buildInfo } = startedBuild;
       const { baseOs, repoVersion } = buildInfo;
 
       const tag = buildId.replace(new RegExp(`^${imageType}-`), '');
 
-      if (publishedDate) {
-        results.push(`[SKIP] "${tag}" has a publishedDate but status is "started". Needs manual review.`);
-        continue;
-      }
-
       const response = await Dockerhub.fetchImageData(imageType, tag);
 
       if (!response) {
-        results.push(`[FAILED] "${tag}" not found on DockerHub. Marking as failed for automatic retry.`);
-        await Discord.sendAlert(`[ManualCleanup] Build for "${tag}" not on DockerHub. Marking as failed.`);
+        results.push(
+          `[FAILED] "${tag}" not found on DockerHub. Marking as failed for automatic retry.`,
+        );
+        await Discord.sendAlert(
+          `[ManualCleanup] Build for "${tag}" not on DockerHub. Marking as failed.`,
+        );
         await CiBuilds.markBuildAsFailed(buildId, {
           reason: `[ManualCleanup] Build never reported back and image not found on DockerHub.`,
         });
@@ -53,8 +51,14 @@ export class Cleaner {
       }
 
       const digest = response.digest || '';
-      results.push(`[PUBLISHED] "${tag}" found on DockerHub (digest: ${digest || 'n/a'}). Marking as published.`);
-      await Discord.sendDebug(`[ManualCleanup] Build for "${tag}" found on DockerHub. Marking as published.`);
+      results.push(
+        `[PUBLISHED] "${tag}" found on DockerHub (digest: ${
+          digest || 'n/a'
+        }). Marking as published.`,
+      );
+      await Discord.sendDebug(
+        `[ManualCleanup] Build for "${tag}" found on DockerHub. Marking as published.`,
+      );
       await CiBuilds.markBuildAsPublished(buildId, jobId, {
         digest,
         specificTag: `${baseOs}-${repoVersion}`,


### PR DESCRIPTION
## Summary

- Removes the `[SKIP]` logic in `manualCleanUp()` that was skipping builds with an existing `publishedDate`
- These builds now go through the normal DockerHub check and get marked as published or failed
- Follow-up to [#82](https://github.com/game-ci/versioning-backend/pull/82) (DockerHub V2 migration + manual cleanup endpoint)

## Why the previous cleanup didn't work

When we ran the cleanup for the first time from the versions page (using the endpoint added in [#82](https://github.com/game-ci/versioning-backend/pull/82)), it found one stuck build but skipped it:

```
Found 1 build(s) with status "started".
[SKIP] "ubuntu-6000.3.7f1-android-3.2.2" has a publishedDate but status is "started". Needs manual review.
```

This happened because `manualCleanUp()` had a guard clause that skipped any build where `meta.publishedDate` already existed. The original reasoning (carried over from the automated cleaner) was caution: if a build has a publication date but is still in "started" status, something unusual happened — maybe a rebuild was requested after the original publish.

However, for a **manual** cleanup explicitly triggered by an admin, this caution is unnecessary. The fix simply removes the guard clause so these builds go through the same DockerHub verification as all other stuck builds: if the image exists on DockerHub, mark it as published; if not, mark it as failed for automatic retry.

The automated cleaner (`cleanUpBuildsThatDidntReportBack`) keeps its own cautious handling of this edge case unchanged.

## Test plan

- [ ] Deploy and trigger cleanup again from the versions page
- [ ] Verify `ubuntu-6000.3.7f1-android-3.2.2` is now processed and marked as `[PUBLISHED]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified internal build queue cleanup process with improved message formatting for internal notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->