### PR TITLE
Fix infinite retry loop from duplicate build dispatches

### DIFF
--- a/functions/src/api/reportNewBuild.ts
+++ b/functions/src/api/reportNewBuild.ts
@@ -42,7 +42,19 @@ export const reportNewBuild = onRequest(
       }
 
       await CiJobs.markJobAsInProgress(jobId);
-      await CiBuilds.registerNewBuild(buildId, jobId, imageType, buildInfo);
+      const { alreadyExists, existingStatus } = await CiBuilds.registerNewBuild(
+        buildId,
+        jobId,
+        imageType,
+        buildInfo,
+      );
+
+      if (alreadyExists) {
+        const message = `Build "${buildId}" already exists with status "${existingStatus}". Duplicate dispatch ignored.`;
+        logger.info(message, body);
+        res.status(409).send(message);
+        return;
+      }
 
       logger.info('new build reported', body);
       res.status(200).send('OK');

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -106,12 +106,17 @@ export class CiBuilds {
     }));
   };
 
+  /**
+   * Registers a new build or handles duplicate dispatches gracefully.
+   * Returns the existing status if the build is already in progress or published,
+   * so the caller can respond appropriately without causing errors.
+   */
   public static registerNewBuild = async (
     buildId: string,
     relatedJobId: string,
     imageType: ImageType,
     buildInfo: BuildInfo,
-  ) => {
+  ): Promise<{ alreadyExists: boolean; existingStatus?: BuildStatus }> => {
     const data: CiBuild = {
       status: 'started',
       buildId,
@@ -135,20 +140,27 @@ export class CiBuilds {
 
     let result;
     if (snapshot.exists) {
+      const existingStatus = snapshot.data()?.status as BuildStatus;
+
       // Builds can be retried after a failure.
-      if (snapshot.data()?.status === 'failed') {
+      if (existingStatus === 'failed') {
         // In case or reporting a new build during retry step, only overwrite these fields
         result = await ref.set(data, {
           mergeFields: ['status', 'meta.lastBuildStart', 'modifiedDate'],
         });
       } else {
-        throw new Error(`A build with "${buildId}" as identifier already exists`);
+        // Build is already in progress or published — duplicate dispatch, not an error.
+        logger.info(
+          `Build "${buildId}" already exists with status "${existingStatus}". Ignoring duplicate dispatch.`,
+        );
+        return { alreadyExists: true, existingStatus };
       }
     } else {
       result = await ref.create(data);
     }
 
     logger.debug('Build created', result);
+    return { alreadyExists: false };
   };
 
   public static async removeDryRunBuild(buildId: string) {
@@ -164,7 +176,14 @@ export class CiBuilds {
   }
 
   public static markBuildAsFailed = async (buildId: string, failure: BuildFailure) => {
-    const build = await db.collection(CiBuilds.collection).doc(buildId);
+    const build = db.collection(CiBuilds.collection).doc(buildId);
+    const snapshot = await build.get();
+
+    // Never overwrite a published build — it was already successfully uploaded.
+    if (snapshot.exists && snapshot.data()?.status === 'published') {
+      logger.warn(`Ignoring failure report for "${buildId}" because it is already published.`);
+      return;
+    }
 
     await build.update({
       status: 'failed',


### PR DESCRIPTION
## Summary

Fixes an infinite retry loop where two simultaneous workflow dispatches for the same image cause builds to cycle between "started" → "failed" every 15 minutes indefinitely.

**Root cause:** When the Ingeminator dispatches retries, two workflows can run simultaneously for the same build. The second gets a 500 from `registerNewBuild` (build already exists as "started"), then the workflow's "Report failure" step marks the build back to "failed" — undoing the first workflow's progress and triggering another retry next cycle.

**Fixes:**

1. **`registerNewBuild` (idempotent):** Returns 409 with a descriptive message for duplicate dispatches instead of throwing a 500. A build already in progress or published is not an error — it's a harmless duplicate dispatch.

2. **`markBuildAsFailed` (guard published):** Refuses to overwrite a "published" build with "failed" status. Once an image is successfully uploaded to DockerHub, a duplicate workflow's failure report should not undo that.

## Observed behavior

Every 15 minutes, the Ingeminator dispatched 2 retries for `6000.3.7f1` and `6000.3.8f1`. One would succeed at building and publishing, but the duplicate would 500 → report failure → reset status to "failed" → infinite loop.

## Test plan

- [ ] Deploy to test environment
- [ ] Verify duplicate `registerNewBuild` calls return 409 instead of 500
- [ ] Verify `markBuildAsFailed` is a no-op for published builds
- [ ] Confirm retry loop stops after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate build submissions are now detected and rejected, preventing redundant processing.
  * Published builds are now protected from being overwritten with failed status, ensuring data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->