### PR TITLE
Fix Ingeminator stall and add resetFailedBuilds endpoint

### DIFF
--- a/functions/src/api/index.ts
+++ b/functions/src/api/index.ts
@@ -4,5 +4,6 @@ export { reportBuildFailure } from './reportBuildFailure';
 export { reportNewBuild } from './reportNewBuild';
 export { reportPublication } from './reportPublication';
 export { unityVersions } from './unityVersions';
+export { resetFailedBuilds } from './resetFailedBuilds';
 export { retryBuild } from './retryBuild';
 export { testFunction } from './testFunction';

--- a/functions/src/api/resetFailedBuilds.ts
+++ b/functions/src/api/resetFailedBuilds.ts
@@ -1,0 +1,114 @@
+import { admin } from '../service/firebase';
+import { onRequest, Request } from 'firebase-functions/v2/https';
+import { Response } from 'express-serve-static-core';
+import { Token } from '../config/token';
+import { CiBuilds } from '../model/ciBuilds';
+import { Discord } from '../service/discord';
+import { logger } from 'firebase-functions/v2';
+import { defineSecret } from 'firebase-functions/params';
+
+const discordToken = defineSecret('DISCORD_TOKEN');
+const internalToken = defineSecret('INTERNAL_TOKEN');
+
+/**
+ * Reset failure counts on failed builds so the Ingeminator can retry them.
+ *
+ * - With `{ buildId }` in the body: resets a single build.
+ * - Without a body: resets ALL failed builds that have hit maxFailuresPerBuild.
+ *
+ * Auth: accepts either the internal versioning token (for CI workflows) or a
+ * Firebase Admin JWT (for the versions page UI).
+ *
+ * Usage: POST /resetFailedBuilds with Authorization: Bearer <token>
+ */
+export const resetFailedBuilds = onRequest(
+  { secrets: [discordToken, internalToken] },
+  async (request: Request, response: Response) => {
+    await Discord.initSafely(discordToken.value());
+
+    try {
+      response.set('Content-Type', 'application/json');
+
+      // Allow pre-flight from cross origin
+      response.set('Access-Control-Allow-Origin', '*');
+      response.set('Access-Control-Allow-Methods', ['POST']);
+      response.set('Access-Control-Allow-Headers', ['Content-Type', 'Authorization']);
+      if (request.method === 'OPTIONS') {
+        response.status(204).send({ message: 'OK' });
+        return;
+      }
+
+      // Authenticate via internal token (CI) or Firebase Admin JWT (UI)
+      const authHeader = request.header('Authorization');
+      const isInternalTokenValid = Token.isValid(authHeader, internalToken.value());
+
+      if (!isInternalTokenValid) {
+        const bearerToken = authHeader?.replace(/^Bearer\s/, '');
+        if (!bearerToken) {
+          response.status(401).send({ message: 'Unauthorized' });
+          return;
+        }
+        try {
+          const user = await admin.auth().verifyIdToken(bearerToken);
+          if (!user || !user.email_verified || !user.admin) {
+            response.status(401).send({ message: 'Unauthorized' });
+            return;
+          }
+        } catch {
+          response.status(401).send({ message: 'Unauthorized' });
+          return;
+        }
+      }
+
+      const results: string[] = [];
+      const { buildId } = request.body || {};
+
+      if (buildId) {
+        // Single build reset
+        const build = await CiBuilds.get(buildId);
+        if (!build) {
+          response.status(404).send({ message: `Build "${buildId}" not found` });
+          return;
+        }
+        if (build.status !== 'failed') {
+          response.status(400).send({
+            message: `Build "${buildId}" has status "${build.status}", expected "failed"`,
+          });
+          return;
+        }
+        await CiBuilds.resetFailureCount(buildId);
+        const msg = `Reset failure count for "${buildId}" (was ${build.meta.failureCount}).`;
+        results.push(msg);
+        logger.info(msg);
+        await Discord.sendDebug(`[ResetFailedBuilds] ${msg}`);
+      } else {
+        // Bulk reset of all maxed-out builds
+        const maxedBuilds = await CiBuilds.getMaxedOutFailedBuilds();
+
+        if (maxedBuilds.length === 0) {
+          results.push('No failed builds at max retries found.');
+        } else {
+          results.push(`Found ${maxedBuilds.length} build(s) at max retries.`);
+          for (const { id, data } of maxedBuilds) {
+            await CiBuilds.resetFailureCount(id);
+            const msg = `Reset "${id}" (was ${data.meta.failureCount} failures).`;
+            results.push(msg);
+          }
+          const summary = `[ResetFailedBuilds] Reset failure counts for ${maxedBuilds.length} build(s).`;
+          logger.info(summary);
+          await Discord.sendDebug(summary);
+        }
+      }
+
+      response.status(200).send({ message: 'Reset completed', results });
+    } catch (error: any) {
+      logger.error('resetFailedBuilds error', error);
+      response.status(500).send({
+        message: 'Internal error during reset',
+        error: error.message,
+      });
+    }
+
+    Discord.disconnect();
+  },
+);

--- a/functions/src/logic/buildQueue/ingeminator.ts
+++ b/functions/src/logic/buildQueue/ingeminator.ts
@@ -83,7 +83,7 @@ export class Ingeminator {
           await Discord.sendDebug(maxRetriesReachedMessage);
         }
 
-        return;
+        continue;
       }
 
       // Incremental backoff

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -216,6 +216,28 @@ export class CiBuilds {
     return parentJobIsNowCompleted;
   };
 
+  public static resetFailureCount = async (buildId: string): Promise<void> => {
+    const build = db.collection(CiBuilds.collection).doc(buildId);
+    await build.update({
+      'meta.failureCount': 0,
+      'meta.lastBuildFailure': null,
+      modifiedDate: Timestamp.now(),
+    });
+  };
+
+  public static getMaxedOutFailedBuilds = async (): Promise<CiBuildQueue> => {
+    const snapshot = await db
+      .collection(CiBuilds.collection)
+      .where('status', '==', 'failed')
+      .where('meta.failureCount', '>=', settings.maxFailuresPerBuild)
+      .get();
+
+    return snapshot.docs.map((doc) => ({
+      id: doc.id,
+      data: doc.data() as CiBuild,
+    }));
+  };
+
   public static haveAllBuildsForJobBeenPublished = async (jobId: string): Promise<boolean> => {
     const snapshot = await db
       .collection(CiBuilds.collection)


### PR DESCRIPTION
## Summary

Two fixes for the build retry pipeline:

1. **Ingeminator `return` → `continue` bug**: The max-retries check used `return` which exits the entire `rescheduleFailedBuildsForJob` function when ANY build in the batch has `failureCount >= maxFailuresPerBuild` (15). This blocks all remaining builds in the same job from being rescheduled. Changed to `continue` to skip maxed-out builds and proceed with others.

2. **New `POST /resetFailedBuilds` endpoint**: Resets inflated failure counts on stuck builds so the Ingeminator can retry them.
   - With `{ buildId }`: resets a single build (used by the versions page UI reset button)
   - Without body: bulk resets ALL failed builds at max retries
   - Auth: internal token or Firebase Admin JWT (same pattern as `cleanUpStuckBuilds`)
   - Sends Discord debug notification on reset

## Root cause

The old 500 error loop (fixed in #84) artificially inflated `failureCount` on many builds. Builds that hit 15+ failures now permanently block the Ingeminator from processing any other builds in the same job — this is why Windows editor builds stopped being dispatched ~2 days ago while Ubuntu builds continued fine.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Deploy and verify Windows builds resume dispatching
- [ ] Verify maxed-out builds are skipped with debug log, not stalling the queue
- [ ] `POST /resetFailedBuilds` resets all maxed-out builds
- [ ] `POST /resetFailedBuilds` with `{ buildId }` resets a single build

🤖 Generated with [Claude Code](https://claude.com/claude-code)