### PR TITLE
Fix resetFailedBuilds 500: avoid compound Firestore query

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,20 @@
       ]
     },
     {
+      "collectionGroup": "ciBuilds",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "meta.failureCount",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "ciJobs",
       "queryScope": "COLLECTION",
       "fields": [

--- a/functions/src/api/resetFailedBuilds.ts
+++ b/functions/src/api/resetFailedBuilds.ts
@@ -77,7 +77,7 @@ export const resetFailedBuilds = onRequest(
           return;
         }
         await CiBuilds.resetFailureCount(buildId);
-        const msg = `Reset failure count for "${buildId}" (was ${build.meta.failureCount}).`;
+        const msg = `Reset failure count for "${buildId}" (was ${build.meta?.failureCount ?? 0}).`;
         results.push(msg);
         logger.info(msg);
         await Discord.sendDebug(`[ResetFailedBuilds] ${msg}`);
@@ -91,7 +91,7 @@ export const resetFailedBuilds = onRequest(
           results.push(`Found ${maxedBuilds.length} build(s) at max retries.`);
           for (const { id, data } of maxedBuilds) {
             await CiBuilds.resetFailureCount(id);
-            const msg = `Reset "${id}" (was ${data.meta.failureCount} failures).`;
+            const msg = `Reset "${id}" (was ${data.meta?.failureCount ?? 0} failures).`;
             results.push(msg);
           }
           const summary = `[ResetFailedBuilds] Reset failure counts for ${maxedBuilds.length} build(s).`;

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -226,16 +226,17 @@ export class CiBuilds {
   };
 
   public static getMaxedOutFailedBuilds = async (): Promise<CiBuildQueue> => {
-    const snapshot = await db
-      .collection(CiBuilds.collection)
-      .where('status', '==', 'failed')
-      .where('meta.failureCount', '>=', settings.maxFailuresPerBuild)
-      .get();
+    const snapshot = await db.collection(CiBuilds.collection).where('status', '==', 'failed').get();
 
-    return snapshot.docs.map((doc) => ({
-      id: doc.id,
-      data: doc.data() as CiBuild,
-    }));
+    return snapshot.docs
+      .filter((doc) => {
+        const data = doc.data() as CiBuild;
+        return (data.meta?.failureCount ?? 0) >= settings.maxFailuresPerBuild;
+      })
+      .map((doc) => ({
+        id: doc.id,
+        data: doc.data() as CiBuild,
+      }));
   };
 
   public static haveAllBuildsForJobBeenPublished = async (jobId: string): Promise<boolean> => {


### PR DESCRIPTION
## Summary

- The `resetFailedBuilds` endpoint returns 500 because `getMaxedOutFailedBuilds()` uses a compound Firestore query (`status` + `meta.failureCount`) that requires a composite index which doesn't exist
- Changed to query by `status == 'failed'` only and filter `failureCount >= maxFailuresPerBuild` in code
- Added the composite index to `firestore.indexes.json` for future optimization
- Added optional chaining on `meta?.failureCount` to prevent null reference errors

## Test plan
- [ ] Deploy and call `POST /resetFailedBuilds` with empty body — should return 200 with reset results
- [ ] Call with `{ buildId: "..." }` for a specific failed build — should reset that build
- [ ] Verify Discord debug notification is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)