### PR TITLE
fix: stop retrying builds that are already published

### DIFF
--- a/functions/src/api/reportBuildFailure.ts
+++ b/functions/src/api/reportBuildFailure.ts
@@ -28,8 +28,14 @@ export const reportBuildFailure = onRequest(
       const { jobId, buildId, reason } = body;
       const failure: BuildFailure = { reason };
 
-      await CiJobs.markFailureForJob(jobId);
-      await CiBuilds.markBuildAsFailed(buildId, failure);
+      const wasMarkedAsFailed = await CiBuilds.markBuildAsFailed(buildId, failure);
+      if (wasMarkedAsFailed) {
+        await CiJobs.markFailureForJob(jobId);
+      } else {
+        logger.info(
+          `Skipping job-level failure for "${jobId}" because build "${buildId}" was not marked as failed.`,
+        );
+      }
 
       logger.info('Build failure reported.', body);
       res.status(200).send('OK');

--- a/functions/src/logic/buildQueue/ingeminator.ts
+++ b/functions/src/logic/buildQueue/ingeminator.ts
@@ -45,9 +45,18 @@ export class Ingeminator {
     const { id: jobId, data: jobData } = job;
     const builds = await CiBuilds.getFailedBuildsQueue(jobId);
     if (builds.length <= 0) {
-      await Discord.sendDebug(
-        `[Ingeminator] Looks like all failed builds for job \`${jobId}\` are already scheduled.`,
-      );
+      // No failed builds — check if all builds are published and heal the job status
+      const allPublished = await CiBuilds.haveAllBuildsForJobBeenPublished(jobId);
+      if (allPublished) {
+        await CiJobs.markJobAsCompleted(jobId);
+        await Discord.sendDebug(
+          `[Ingeminator] All builds for job \`${jobId}\` are published. Marked job as completed.`,
+        );
+      } else {
+        await Discord.sendDebug(
+          `[Ingeminator] Looks like all failed builds for job \`${jobId}\` are already scheduled.`,
+        );
+      }
       return;
     }
 

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -175,14 +175,17 @@ export class CiBuilds {
     await ref.delete();
   }
 
-  public static markBuildAsFailed = async (buildId: string, failure: BuildFailure) => {
+  public static markBuildAsFailed = async (
+    buildId: string,
+    failure: BuildFailure,
+  ): Promise<boolean> => {
     const build = db.collection(CiBuilds.collection).doc(buildId);
     const snapshot = await build.get();
 
     // Never overwrite a published build — it was already successfully uploaded.
     if (snapshot.exists && snapshot.data()?.status === 'published') {
       logger.warn(`Ignoring failure report for "${buildId}" because it is already published.`);
-      return;
+      return false;
     }
 
     await build.update({
@@ -192,6 +195,8 @@ export class CiBuilds {
       'meta.failureCount': FieldValue.increment(1),
       'meta.lastBuildFailure': Timestamp.now(),
     });
+
+    return true;
   };
 
   public static markBuildAsPublished = async (


### PR DESCRIPTION
## Summary

- **`reportBuildFailure`** unconditionally called `markFailureForJob` even when the build was already published. Since `markBuildAsFailed` silently ignores published builds, the job kept getting flipped back to "failed" while no build-level data changed. This caused the Ingeminator to endlessly retry already-published images (like `6000.3.7f1-android`, `6000.3.8f1-android`) every 15 minutes, clogging the retry queue and preventing genuinely missing builds (6000.3.12f1+) from being dispatched.

- **`markBuildAsFailed`** now returns `boolean` — `true` if the failure was recorded, `false` if skipped (build already published). `reportBuildFailure` only marks the parent job as failed when the build was actually marked.

- **Ingeminator** now heals orphaned "failed" jobs: when a job has status "failed" but zero failed builds (all published), it marks the job as completed instead of silently returning. This fixes jobs already stuck in the bad state.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` passes  
- [x] `yarn test:run` — all 7 tests pass
- [ ] After deploy: verify Ingeminator marks orphaned failed jobs as completed (check Discord debug channel)
- [ ] After deploy: verify retry queue advances to genuinely missing builds (6000.3.12f1+)
- [ ] After deploy: confirm no more retry dispatches for already-published images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build failure tracking to skip job-level updates when a build cannot be marked as failed.
  * Fixed job completion status to update correctly when all builds have been published.

* **Refactor**
  * Enhanced internal failure reporting logic for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->