### PR TITLE
fix: check DockerHub before dispatching retries in Ingeminator

### DIFF
--- a/functions/src/logic/buildQueue/ingeminator.ts
+++ b/functions/src/logic/buildQueue/ingeminator.ts
@@ -2,6 +2,7 @@ import { CiJob, CiJobQueue, CiJobQueueItem, CiJobs } from '../../model/ciJobs';
 import { CiBuild, CiBuilds } from '../../model/ciBuilds';
 import { EditorVersionInfo } from '../../model/editorVersionInfo';
 import { Discord } from '../../service/discord';
+import { Dockerhub } from '../../service/dockerhub';
 import { Octokit } from '@octokit/rest';
 import { RepoVersionInfo } from '../../model/repoVersionInfo';
 import { Scheduler } from './scheduler';
@@ -101,6 +102,25 @@ export class Ingeminator {
       if (lastFailure.toMillis() + backoffMilliseconds >= Timestamp.now().toMillis()) {
         await Discord.sendDebug(
           `[Ingeminator] Backoff period of ${backoffMinutes} minutes has not expired for ${buildId}.`,
+        );
+        continue;
+      }
+
+      // Check DockerHub before dispatching — the image may already exist
+      const { imageType, buildInfo } = BuildData;
+      const tag = buildId.replace(new RegExp(`^${imageType}-`), '');
+      const existingImage = await Dockerhub.fetchImageData(imageType, tag);
+      if (existingImage) {
+        const digest = existingImage.digest || '';
+        await CiBuilds.markBuildAsPublished(buildId, jobId, {
+          digest,
+          specificTag: `${buildInfo.baseOs}-${buildInfo.repoVersion}`,
+          friendlyTag: buildInfo.repoVersion.replace(/\.\d+$/, ''),
+          imageName: Dockerhub.getImageName(imageType),
+          imageRepo: Dockerhub.getRepositoryBaseName(),
+        });
+        await Discord.sendDebug(
+          `[Ingeminator] Build "${buildId}" already exists on DockerHub. Marked as published.`,
         );
         continue;
       }


### PR DESCRIPTION
## Summary

Follows up on #87. The previous fix prevented *new* failure reports from re-marking jobs as failed, but builds that were already `status: 'failed'` in Firestore with images that exist on DockerHub continued to be retried endlessly.

- **Root cause**: A build can be "failed" in Firestore while the image actually exists on DockerHub (e.g. the workflow pushed the image but crashed before the "Report publication" step ran). The Ingeminator dispatched retries for these, the retry workflow detected the image and exited early, but Firestore was never updated — infinite loop.

- **Fix**: Before dispatching each retry, the Ingeminator now checks DockerHub. If the image already exists, it marks the build as published directly (same pattern the Cleaner uses) and skips the dispatch. This heals the Firestore state and unblocks the queue.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [x] `yarn test:run` — all 7 tests pass
- [ ] After deploy: verify builds like `6000.3.7f1-android` get marked as published in Firestore
- [ ] After deploy: verify retry dispatches stop for already-published images
- [ ] After deploy: verify queue advances to genuinely missing builds (6000.3.12f1+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failed build handling by checking for existing Docker images before rescheduling. Builds with already-available images are now automatically marked as published, preventing redundant scheduling attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->