### PR TITLE
fix: increase cron timeout from 60s to 300s

### DIFF
--- a/functions/src/cron/index.ts
+++ b/functions/src/cron/index.ts
@@ -17,12 +17,12 @@ if (MINUTES < 10) {
   throw new Error('Is the result really worth the machine time? Remove me.');
 }
 
-// Timeout of 60 seconds will keep our routine process tight.
+// Timeout increased to accommodate DockerHub checks during build healing.
 export const trigger = onSchedule(
   {
     schedule: `every ${MINUTES} minutes`,
     memory: '512MiB',
-    timeoutSeconds: 60,
+    timeoutSeconds: 300,
     secrets: [discordToken, githubPrivateKeyConfigSecret, githubClientSecretConfigSecret],
   },
   async () => {


### PR DESCRIPTION
## Summary

The cron function's 60-second timeout is too short now that the Ingeminator checks DockerHub before dispatching retries (#88). With many failed jobs to heal (each requiring multiple DockerHub API calls), the function times out before finishing, preventing new builds from ever being scheduled.

Increases timeout to 300s (5 min), well within the 15-min scan interval.

## Test plan

- [x] Lint + tests pass
- [ ] After deploy: verify scheduler completes full cycle (check Discord #backend for "begin"/"end" messages)
- [ ] After deploy: verify new builds get dispatched for missing versions (6000.3.12f1+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended timeout duration for scheduled background operations to improve reliability and prevent premature termination of long-running tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->