### PR TITLE
fix: reconcile failed builds against DockerHub in the Cleaner

### DIFF
--- a/functions/src/logic/buildQueue/cleaner.ts
+++ b/functions/src/logic/buildQueue/cleaner.ts
@@ -11,6 +11,7 @@ export class Cleaner {
   public static async cleanUp() {
     this.buildsProcessed = 0;
     await this.cleanUpBuildsThatDidntReportBack();
+    await this.healFailedBuildsAlreadyOnDockerHub();
   }
 
   /**
@@ -69,6 +70,42 @@ export class Cleaner {
     }
 
     return results;
+  }
+
+  /**
+   * Reconcile "failed" builds against DockerHub.
+   * A build can end up "failed" in Firestore while the image was actually
+   * pushed to DockerHub (e.g. the workflow pushed the image but crashed
+   * before reporting publication). Mark these as published so the
+   * Ingeminator stops retrying them.
+   */
+  private static async healFailedBuildsAlreadyOnDockerHub() {
+    const failedBuilds = await CiBuilds.getFailedBuilds(this.maxBuildsProcessedPerRun);
+
+    for (const failedBuild of failedBuilds) {
+      if (this.buildsProcessed >= this.maxBuildsProcessedPerRun) return;
+
+      const { buildId, relatedJobId: jobId, imageType, buildInfo } = failedBuild;
+      const { baseOs, repoVersion } = buildInfo;
+      const tag = buildId.replace(new RegExp(`^${imageType}-`), '');
+
+      this.buildsProcessed += 1;
+
+      const response = await Dockerhub.fetchImageData(imageType, tag);
+      if (!response) continue;
+
+      const digest = response.digest || '';
+      await Discord.sendDebug(
+        `[Cleaner] Build "${tag}" is "failed" but exists on DockerHub. Marking as published.`,
+      );
+      await CiBuilds.markBuildAsPublished(buildId, jobId, {
+        digest,
+        specificTag: `${baseOs}-${repoVersion}`,
+        friendlyTag: repoVersion.replace(/\.\d+$/, ''),
+        imageName: Dockerhub.getImageName(imageType),
+        imageRepo: Dockerhub.getRepositoryBaseName(),
+      });
+    }
   }
 
   private static async cleanUpBuildsThatDidntReportBack() {

--- a/functions/src/logic/buildQueue/ingeminator.ts
+++ b/functions/src/logic/buildQueue/ingeminator.ts
@@ -2,7 +2,6 @@ import { CiJob, CiJobQueue, CiJobQueueItem, CiJobs } from '../../model/ciJobs';
 import { CiBuild, CiBuilds } from '../../model/ciBuilds';
 import { EditorVersionInfo } from '../../model/editorVersionInfo';
 import { Discord } from '../../service/discord';
-import { Dockerhub } from '../../service/dockerhub';
 import { Octokit } from '@octokit/rest';
 import { RepoVersionInfo } from '../../model/repoVersionInfo';
 import { Scheduler } from './scheduler';
@@ -46,18 +45,9 @@ export class Ingeminator {
     const { id: jobId, data: jobData } = job;
     const builds = await CiBuilds.getFailedBuildsQueue(jobId);
     if (builds.length <= 0) {
-      // No failed builds — check if all builds are published and heal the job status
-      const allPublished = await CiBuilds.haveAllBuildsForJobBeenPublished(jobId);
-      if (allPublished) {
-        await CiJobs.markJobAsCompleted(jobId);
-        await Discord.sendDebug(
-          `[Ingeminator] All builds for job \`${jobId}\` are published. Marked job as completed.`,
-        );
-      } else {
-        await Discord.sendDebug(
-          `[Ingeminator] Looks like all failed builds for job \`${jobId}\` are already scheduled.`,
-        );
-      }
+      await Discord.sendDebug(
+        `[Ingeminator] Looks like all failed builds for job \`${jobId}\` are already scheduled.`,
+      );
       return;
     }
 
@@ -102,25 +92,6 @@ export class Ingeminator {
       if (lastFailure.toMillis() + backoffMilliseconds >= Timestamp.now().toMillis()) {
         await Discord.sendDebug(
           `[Ingeminator] Backoff period of ${backoffMinutes} minutes has not expired for ${buildId}.`,
-        );
-        continue;
-      }
-
-      // Check DockerHub before dispatching — the image may already exist
-      const { imageType, buildInfo } = BuildData;
-      const tag = buildId.replace(new RegExp(`^${imageType}-`), '');
-      const existingImage = await Dockerhub.fetchImageData(imageType, tag);
-      if (existingImage) {
-        const digest = existingImage.digest || '';
-        await CiBuilds.markBuildAsPublished(buildId, jobId, {
-          digest,
-          specificTag: `${buildInfo.baseOs}-${buildInfo.repoVersion}`,
-          friendlyTag: buildInfo.repoVersion.replace(/\.\d+$/, ''),
-          imageName: Dockerhub.getImageName(imageType),
-          imageRepo: Dockerhub.getRepositoryBaseName(),
-        });
-        await Discord.sendDebug(
-          `[Ingeminator] Build "${buildId}" already exists on DockerHub. Marked as published.`,
         );
         continue;
       }

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -230,6 +230,16 @@ export class CiBuilds {
     });
   };
 
+  public static getFailedBuilds = async (limit: number): Promise<CiBuild[]> => {
+    const snapshot = await db
+      .collection(CiBuilds.collection)
+      .where('status', '==', 'failed')
+      .limit(limit)
+      .get();
+
+    return snapshot.docs.map((doc) => doc.data() as CiBuild);
+  };
+
   public static getMaxedOutFailedBuilds = async (): Promise<CiBuildQueue> => {
     const snapshot = await db.collection(CiBuilds.collection).where('status', '==', 'failed').get();
 


### PR DESCRIPTION
## Summary

Builds can be "failed" in Firestore while the image actually exists on DockerHub (e.g. the workflow pushed the image but crashed before reporting publication). The Ingeminator retries these endlessly since the retry workflow exits early without updating Firestore.

**Fix**: Extend the Cleaner to also reconcile "failed" builds — the same pattern it already uses for "started" builds that didn't report back. Rate-limited to 5 builds per cycle. `markBuildAsPublished` automatically marks the parent job as completed when all builds are published.

**Reverts #88's Ingeminator changes** — DockerHub checks don't belong in the Ingeminator's hot path (caused Cloud Functions timeouts). The Cleaner is the right place for DockerHub reconciliation.

## Changes

- **`cleaner.ts`**: Added `healFailedBuildsAlreadyOnDockerHub()` — queries failed builds, checks DockerHub, marks as published if image exists
- **`ciBuilds.ts`**: Added `getFailedBuilds(limit)` query
- **`ingeminator.ts`**: Reverted to original (removed DockerHub check and redundant job-healing code)

## Test plan

- [x] Lint + tests pass
- [ ] After deploy: verify Cleaner heals failed builds (Discord #backend: `[Cleaner] Build "..." is "failed" but exists on DockerHub`)
- [ ] After deploy: verify jobs auto-complete when all builds are published
- [ ] After deploy: verify new builds get dispatched for missing versions (6000.3.12f1+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failed build recovery by correctly identifying when builds are already published on Docker Hub, preventing unnecessary reprocessing.
  * Streamlined build scheduling logic to reduce redundant checks and improve processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->