### PR TITLE
fix: supersede old-version jobs before scheduling

### DIFF
--- a/functions/src/logic/buildQueue/scheduleBuildsFromTheQueue.ts
+++ b/functions/src/logic/buildQueue/scheduleBuildsFromTheQueue.ts
@@ -1,6 +1,7 @@
 import { RepoVersionInfo } from '../../model/repoVersionInfo';
 import { Scheduler } from './scheduler';
 import { Discord } from '../../service/discord';
+import { CiJobs } from '../../model/ciJobs';
 
 /**
  * When a new Unity version gets ingested:
@@ -19,6 +20,16 @@ export const scheduleBuildsFromTheQueue = async (
   githubClientSecret: string,
 ) => {
   const repoVersionInfo = await RepoVersionInfo.getLatest();
+  const numSuperseded = await CiJobs.markJobsBeforeRepoVersionAsSuperseded(repoVersionInfo.version);
+
+  if (numSuperseded >= 1) {
+    await Discord.sendDebug(
+      `[Build queue] Superseded ${CiJobs.pluralise(
+        numSuperseded,
+      )} from older repo versions before scheduling.`,
+    );
+  }
+
   const scheduler = await new Scheduler(repoVersionInfo).init(githubPrivateKey, githubClientSecret);
 
   const testVersion = '0.1.0';


### PR DESCRIPTION
## Summary
Supersede stale `created` and `failed` jobs from older repo versions at the start of each cron scheduling cycle.

## Why
The queue was still retrying old `3.2.1` jobs against the latest repo version, `3.2.2`, producing duplicate-dispatch churn for images that were already published and blocking newer jobs from being scheduled.

## Change
- Call `CiJobs.markJobsBeforeRepoVersionAsSuperseded(repoVersionInfo.version)` from `scheduleBuildsFromTheQueue`.
- Log when older jobs were superseded before the scheduler runs.

## Validation
- `yarn workspace functions build`

## Expected Effect
Old failed jobs like `editor-6000.3.5f2-3.2.1` through `editor-6000.3.9f1-3.2.1` stop competing with the latest queue, allowing current `3.2.2` jobs such as `editor-6000.3.12f1-3.2.2` to move forward.
