### PR TITLE
fix: retry builds with the job repo version

### DIFF
--- a/functions/src/api/retryBuild.ts
+++ b/functions/src/api/retryBuild.ts
@@ -5,7 +5,6 @@ import { CiBuilds } from '../model/ciBuilds';
 import { CiJobs } from '../model/ciJobs';
 import { Ingeminator } from '../logic/buildQueue/ingeminator';
 import { GitHub } from '../service/github';
-import { RepoVersionInfo } from '../model/repoVersionInfo';
 import { Discord } from '../service/discord';
 import { defineSecret } from 'firebase-functions/params';
 
@@ -79,8 +78,7 @@ export const retryBuild = onRequest(
 
       // Schedule new build
       const gitHubClient = await GitHub.init(githubPrivateKey.value(), githubClientSecret.value());
-      const repoVersionInfo = await RepoVersionInfo.getLatest();
-      const scheduler = new Ingeminator(1, gitHubClient, repoVersionInfo);
+      const scheduler = new Ingeminator(1, gitHubClient);
       const scheduledSuccessfully = await scheduler.rescheduleBuild(jobId, job, buildId, build);
 
       // Report result

--- a/functions/src/logic/buildQueue/ingeminator.ts
+++ b/functions/src/logic/buildQueue/ingeminator.ts
@@ -3,7 +3,6 @@ import { CiBuild, CiBuilds } from '../../model/ciBuilds';
 import { EditorVersionInfo } from '../../model/editorVersionInfo';
 import { Discord } from '../../service/discord';
 import { Octokit } from '@octokit/rest';
-import { RepoVersionInfo } from '../../model/repoVersionInfo';
 import { Scheduler } from './scheduler';
 import admin from 'firebase-admin';
 import Timestamp = admin.firestore.Timestamp;
@@ -15,12 +14,10 @@ import { logger } from 'firebase-functions/v2';
 export class Ingeminator {
   numberToSchedule: number;
   gitHubClient: Octokit;
-  repoVersionInfo: RepoVersionInfo;
 
-  constructor(numberToSchedule: number, gitHubClient: Octokit, repoVersionInfo: RepoVersionInfo) {
+  constructor(numberToSchedule: number, gitHubClient: Octokit) {
     this.numberToSchedule = numberToSchedule;
     this.gitHubClient = gitHubClient;
-    this.repoVersionInfo = repoVersionInfo;
   }
 
   async rescheduleFailedJobs(jobs: CiJobQueue) {
@@ -117,7 +114,7 @@ export class Ingeminator {
     const { baseOs, targetPlatform } = buildInfo;
 
     // Info from repo
-    const repoVersions = Scheduler.parseRepoVersions(this.repoVersionInfo);
+    const repoVersions = Scheduler.parseRepoVersions(jobData.repoVersionInfo);
     const { repoVersionFull, repoVersionMinor, repoVersionMajor } = repoVersions;
 
     // Send the retry request

--- a/functions/src/logic/buildQueue/scheduler.ts
+++ b/functions/src/logic/buildQueue/scheduler.ts
@@ -176,7 +176,7 @@ export class Scheduler {
         return false;
       }
 
-      const ingeminator = new Ingeminator(numberToReschedule, this.gitHub, this.repoVersionInfo);
+      const ingeminator = new Ingeminator(numberToReschedule, this.gitHub);
       await ingeminator.rescheduleFailedJobs(failingJobs);
     }
 


### PR DESCRIPTION
## Summary
- make retry dispatch use the parent job's recorded repo version
- stop `retryBuild` from pulling `RepoVersionInfo.getLatest()` for manual retries
- keep `#91` as the queue-pressure mitigation and make retries themselves version-correct

## Problem
Old jobs from one repo version could be retried using a newer repo version.

In practice we saw cases like:
- job id: `editor-6000.3.6f1-3.2.1`
- retry payload repo version: `3.2.2`

That creates repo-version drift between the parent job and the retried build. Once newer images already exist on DockerHub, that drift can produce duplicate-dispatch churn and make the queue less reliable.

## Fix
Use `jobData.repoVersionInfo` when dispatching retries, both from the scheduler path and the admin `retryBuild` endpoint.

That preserves the original contract of the job being retried:
- same editor version
- same target platform
- same base OS
- same repo version

## Validation
- `yarn workspace functions build`

## Related
- `#91` mitigates stale old-version jobs blocking the queue
- this PR fixes the underlying retry correctness issue directly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal build queue management to streamline dependency handling and improve code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->