### PR TITLE
Auto-Recover Stuck Queue Builds And Fix Queue Status API

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -121,6 +121,20 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "ciBuilds",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "buildInfo.repoVersion",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/src/api/queueStatus.ts
+++ b/functions/src/api/queueStatus.ts
@@ -4,8 +4,20 @@ import { CiJobs } from '../model/ciJobs';
 import { CiBuilds } from '../model/ciBuilds';
 
 export const queueStatus = onRequest(async (req: Request, res: Response) => {
-  const jobs = await CiJobs.getAll();
-  const builds = await CiBuilds.getAll();
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
 
-  res.status(200).send({ jobs, builds });
+  if (req.method === 'OPTIONS') {
+    res.status(204).send();
+    return;
+  }
+
+  const repoVersion = typeof req.query.repoVersion === 'string' ? req.query.repoVersion : '';
+  const jobs = await CiJobs.getAll();
+  const builds = repoVersion
+    ? await CiBuilds.getAllForRepoVersion(repoVersion)
+    : await CiBuilds.getAll();
+
+  res.status(200).send({ jobs, builds, repoVersion: repoVersion || null });
 });

--- a/functions/src/api/retryBuild.ts
+++ b/functions/src/api/retryBuild.ts
@@ -5,7 +5,6 @@ import { CiBuilds } from '../model/ciBuilds';
 import { CiJobs } from '../model/ciJobs';
 import { Ingeminator } from '../logic/buildQueue/ingeminator';
 import { GitHub } from '../service/github';
-import { RepoVersionInfo } from '../model/repoVersionInfo';
 import { Discord } from '../service/discord';
 import { defineSecret } from 'firebase-functions/params';
 
@@ -79,8 +78,7 @@ export const retryBuild = onRequest(
 
       // Schedule new build
       const gitHubClient = await GitHub.init(githubPrivateKey.value(), githubClientSecret.value());
-      const repoVersionInfo = await RepoVersionInfo.getLatest();
-      const scheduler = new Ingeminator(1, gitHubClient, repoVersionInfo);
+      const scheduler = new Ingeminator(1, gitHubClient);
       const scheduledSuccessfully = await scheduler.rescheduleBuild(jobId, job, buildId, build);
 
       // Report result

--- a/functions/src/logic/buildQueue/cleaner.ts
+++ b/functions/src/logic/buildQueue/cleaner.ts
@@ -15,18 +15,40 @@ export class Cleaner {
   }
 
   /**
+   * A build that has been auto-recovered this many times will not be reset
+   * again. Beyond this point the build is almost certainly fundamentally
+   * broken (e.g. an unbuildable editor version on a given base OS); further
+   * resets only burn GitHub Actions minutes and DockerHub API quota.
+   */
+  static readonly maxRecoveryAttempts: number = 2;
+
+  /**
    * Automatically recover maxed-out failed builds for the latest repo version.
    * If the image is already on DockerHub, mark it as published.
    * Otherwise reset its failure count so the Ingeminator can retry it again.
+   *
+   * Per run we process at most `maxBuildsProcessedPerRun` builds and we cap
+   * the number of times any single build can be auto-reset. Builds that
+   * exceed `maxRecoveryAttempts` are left alone and an alert is sent so a
+   * maintainer can investigate.
    */
   public static async recoverMaxedOutFailedBuilds(repoVersion: string): Promise<string[]> {
     const results: string[] = [];
     const maxedBuilds = await CiBuilds.getMaxedOutFailedBuildsForRepoVersion(repoVersion);
 
+    let processed = 0;
     for (const { id: buildId, data: build } of maxedBuilds) {
-      const { relatedJobId: jobId, imageType, buildInfo } = build;
+      if (processed >= this.maxBuildsProcessedPerRun) {
+        results.push(`deferred:${buildId}`);
+        continue;
+      }
+
+      const { relatedJobId: jobId, imageType, buildInfo, meta } = build;
       const { baseOs } = buildInfo;
       const tag = buildId.replace(new RegExp(`^${imageType}-`), '');
+      const recoveryCount = meta?.recoveryCount ?? 0;
+
+      processed += 1;
 
       const response = await Dockerhub.fetchImageData(imageType, tag);
       if (response) {
@@ -45,9 +67,21 @@ export class Cleaner {
         continue;
       }
 
+      if (recoveryCount >= this.maxRecoveryAttempts) {
+        await Discord.sendAlert(
+          `[Cleaner] Build "${tag}" has been auto-recovered ${recoveryCount} time(s) and is still failing. ` +
+            `Leaving it at max retries - manual investigation required.`,
+        );
+        results.push(`exhausted:${buildId}`);
+        continue;
+      }
+
       await CiBuilds.resetFailureCount(buildId);
+      await CiBuilds.incrementRecoveryCount(buildId);
       await Discord.sendAlert(
-        `[Cleaner] Reset failure count for maxed-out build "${tag}" so it can retry automatically.`,
+        `[Cleaner] Reset failure count for maxed-out build "${tag}" (recovery attempt ${
+          recoveryCount + 1
+        }/${this.maxRecoveryAttempts}).`,
       );
       results.push(`reset:${buildId}`);
     }

--- a/functions/src/logic/buildQueue/cleaner.ts
+++ b/functions/src/logic/buildQueue/cleaner.ts
@@ -15,6 +15,47 @@ export class Cleaner {
   }
 
   /**
+   * Automatically recover maxed-out failed builds for the latest repo version.
+   * If the image is already on DockerHub, mark it as published.
+   * Otherwise reset its failure count so the Ingeminator can retry it again.
+   */
+  public static async recoverMaxedOutFailedBuilds(repoVersion: string): Promise<string[]> {
+    const results: string[] = [];
+    const maxedBuilds = await CiBuilds.getMaxedOutFailedBuildsForRepoVersion(repoVersion);
+
+    for (const { id: buildId, data: build } of maxedBuilds) {
+      const { relatedJobId: jobId, imageType, buildInfo } = build;
+      const { baseOs } = buildInfo;
+      const tag = buildId.replace(new RegExp(`^${imageType}-`), '');
+
+      const response = await Dockerhub.fetchImageData(imageType, tag);
+      if (response) {
+        const digest = response.digest || '';
+        await Discord.sendDebug(
+          `[Cleaner] Maxed-out build "${tag}" already exists on DockerHub. Marking as published.`,
+        );
+        await CiBuilds.markBuildAsPublished(buildId, jobId, {
+          digest,
+          specificTag: `${baseOs}-${repoVersion}`,
+          friendlyTag: repoVersion.replace(/\.\d+$/, ''),
+          imageName: Dockerhub.getImageName(imageType),
+          imageRepo: Dockerhub.getRepositoryBaseName(),
+        });
+        results.push(`published:${buildId}`);
+        continue;
+      }
+
+      await CiBuilds.resetFailureCount(buildId);
+      await Discord.sendAlert(
+        `[Cleaner] Reset failure count for maxed-out build "${tag}" so it can retry automatically.`,
+      );
+      results.push(`reset:${buildId}`);
+    }
+
+    return results;
+  }
+
+  /**
    * Manual cleanup for maintainers. Processes all stuck builds without the
    * 6-hour wait and without the per-run build limit.
    * Returns a summary of actions taken.

--- a/functions/src/logic/buildQueue/ingeminator.ts
+++ b/functions/src/logic/buildQueue/ingeminator.ts
@@ -3,7 +3,6 @@ import { CiBuild, CiBuilds } from '../../model/ciBuilds';
 import { EditorVersionInfo } from '../../model/editorVersionInfo';
 import { Discord } from '../../service/discord';
 import { Octokit } from '@octokit/rest';
-import { RepoVersionInfo } from '../../model/repoVersionInfo';
 import { Scheduler } from './scheduler';
 import admin from 'firebase-admin';
 import Timestamp = admin.firestore.Timestamp;
@@ -15,12 +14,10 @@ import { logger } from 'firebase-functions/v2';
 export class Ingeminator {
   numberToSchedule: number;
   gitHubClient: Octokit;
-  repoVersionInfo: RepoVersionInfo;
 
-  constructor(numberToSchedule: number, gitHubClient: Octokit, repoVersionInfo: RepoVersionInfo) {
+  constructor(numberToSchedule: number, gitHubClient: Octokit) {
     this.numberToSchedule = numberToSchedule;
     this.gitHubClient = gitHubClient;
-    this.repoVersionInfo = repoVersionInfo;
   }
 
   async rescheduleFailedJobs(jobs: CiJobQueue) {
@@ -117,7 +114,7 @@ export class Ingeminator {
     const { baseOs, targetPlatform } = buildInfo;
 
     // Info from repo
-    const repoVersions = Scheduler.parseRepoVersions(this.repoVersionInfo);
+    const repoVersions = Scheduler.parseRepoVersions(jobData.repoVersionInfo);
     const { repoVersionFull, repoVersionMinor, repoVersionMajor } = repoVersions;
 
     // Send the retry request

--- a/functions/src/logic/buildQueue/ingeminator.ts
+++ b/functions/src/logic/buildQueue/ingeminator.ts
@@ -62,7 +62,10 @@ export class Ingeminator {
       // Max retries check
       const { maxFailuresPerBuild } = settings;
       const { lastBuildFailure, failureCount } = build.data.meta;
-      const lastFailure = lastBuildFailure as Timestamp;
+      // `lastBuildFailure` can be null after Cleaner.recoverMaxedOutFailedBuilds
+      // or the admin reset endpoint clears it. Fall back to the epoch so the
+      // backoff window is always considered elapsed.
+      const lastFailure = lastBuildFailure ?? Timestamp.fromMillis(0);
       if (failureCount >= maxFailuresPerBuild) {
         // Log warning
         const retries: number = maxFailuresPerBuild - 1;

--- a/functions/src/logic/buildQueue/scheduleBuildsFromTheQueue.ts
+++ b/functions/src/logic/buildQueue/scheduleBuildsFromTheQueue.ts
@@ -2,6 +2,7 @@ import { RepoVersionInfo } from '../../model/repoVersionInfo';
 import { Scheduler } from './scheduler';
 import { Discord } from '../../service/discord';
 import { CiJobs } from '../../model/ciJobs';
+import { Cleaner } from './cleaner';
 
 /**
  * When a new Unity version gets ingested:
@@ -27,6 +28,13 @@ export const scheduleBuildsFromTheQueue = async (
       `[Build queue] Superseded ${CiJobs.pluralise(
         numSuperseded,
       )} from older repo versions before scheduling.`,
+    );
+  }
+
+  const recoveredBuilds = await Cleaner.recoverMaxedOutFailedBuilds(repoVersionInfo.version);
+  if (recoveredBuilds.length >= 1) {
+    await Discord.sendDebug(
+      `[Build queue] Recovered ${recoveredBuilds.length} maxed-out failed build(s) for repo version ${repoVersionInfo.version}.`,
     );
   }
 

--- a/functions/src/logic/buildQueue/scheduler.ts
+++ b/functions/src/logic/buildQueue/scheduler.ts
@@ -176,7 +176,7 @@ export class Scheduler {
         return false;
       }
 
-      const ingeminator = new Ingeminator(numberToReschedule, this.gitHub, this.repoVersionInfo);
+      const ingeminator = new Ingeminator(numberToReschedule, this.gitHub);
       await ingeminator.rescheduleFailedJobs(failingJobs);
     }
 

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -70,6 +70,15 @@ export class CiBuilds {
     return snapshot.docs.map((doc) => doc.data()) as CiBuild[];
   };
 
+  public static getAllForRepoVersion = async (repoVersion: string): Promise<CiBuild[]> => {
+    const snapshot = await db
+      .collection(CiBuilds.collection)
+      .where('buildInfo.repoVersion', '==', repoVersion)
+      .get();
+
+    return snapshot.docs.map((doc) => doc.data()) as CiBuild[];
+  };
+
   public static get = async (buildId: string): Promise<CiBuild | null> => {
     const snapshot = await db.doc(`${CiBuilds.collection}/${buildId}`).get();
 

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -36,6 +36,7 @@ interface MetaData {
   failureCount: number;
   lastBuildFailure: Timestamp | null;
   publishedDate: Timestamp | null;
+  recoveryCount?: number;
 }
 
 export interface CiBuild {
@@ -232,9 +233,19 @@ export class CiBuilds {
 
   public static resetFailureCount = async (buildId: string): Promise<void> => {
     const build = db.collection(CiBuilds.collection).doc(buildId);
+    // Use an epoch sentinel rather than null so the Ingeminator's backoff math
+    // (lastBuildFailure.toMillis() + backoffMs) never reads null at runtime.
     await build.update({
       'meta.failureCount': 0,
-      'meta.lastBuildFailure': null,
+      'meta.lastBuildFailure': Timestamp.fromMillis(0),
+      modifiedDate: Timestamp.now(),
+    });
+  };
+
+  public static incrementRecoveryCount = async (buildId: string): Promise<void> => {
+    const build = db.collection(CiBuilds.collection).doc(buildId);
+    await build.update({
+      'meta.recoveryCount': FieldValue.increment(1),
       modifiedDate: Timestamp.now(),
     });
   };

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -263,6 +263,26 @@ export class CiBuilds {
       }));
   };
 
+  public static getMaxedOutFailedBuildsForRepoVersion = async (
+    repoVersion: string,
+  ): Promise<CiBuildQueue> => {
+    const snapshot = await db
+      .collection(CiBuilds.collection)
+      .where('status', '==', 'failed')
+      .where('buildInfo.repoVersion', '==', repoVersion)
+      .get();
+
+    return snapshot.docs
+      .filter((doc) => {
+        const data = doc.data() as CiBuild;
+        return (data.meta?.failureCount ?? 0) >= settings.maxFailuresPerBuild;
+      })
+      .map((doc) => ({
+        id: doc.id,
+        data: doc.data() as CiBuild,
+      }));
+  };
+
   public static haveAllBuildsForJobBeenPublished = async (jobId: string): Promise<boolean> => {
     const snapshot = await db
       .collection(CiBuilds.collection)


### PR DESCRIPTION
## Summary
- fix `queueStatus` cross-origin access for the docs admin UI
- filter queue-status build data by Docker repo version
- automatically recover maxed-out failed builds for the latest repo version, with safety caps so broken builds cannot loop forever
- fix `retryBuild` to use the job's repo version instead of the latest

## Problem
The docs site calls `queueStatus` cross-origin from `game.ci`. Without CORS headers the browser fails the request with `Failed to fetch`, which breaks Admin Queue Management.

Separately, retry-exhausted failed builds required a manual `resetFailedBuilds` call before the queue could retry them again. Because the scheduler prioritises failed jobs before new `created` editor jobs, that left newer editor versions stuck behind stale failures and required admin intervention. We saw this on repo version 3.2.2 (Total 7108, Published 7099, In progress 0, ~9 failed) where created jobs for newer editors were showing the builder-head icon on the docs site indefinitely.

## Changes
- add CORS + `OPTIONS` handling to `queueStatus`
- support repo-version-scoped build queries in `queueStatus` (jobs remain global, builds are filtered)
- add repo-version-scoped lookup for maxed-out failed builds
- `retryBuild`: dispatch with the build's own `jobData.repoVersionInfo` rather than `RepoVersionInfo.getLatest()`, so retrying an older repo version no longer mislabels the dispatch as the current latest
- during the scheduled queue pass, automatically recover maxed-out failed builds for the latest repo version:
  - if the image already exists on Docker Hub, mark it published (same logic as the existing `healFailedBuildsAlreadyOnDockerHub` heuristic, but applied to the maxed-out subset)
  - otherwise reset its failure count so automatic retries can resume

## Recovery safety caps (why)
First-pass review caught three failure modes in the naive recovery path; this PR addresses each:

1. **Ingeminator NPE after reset.** `resetFailureCount` previously wrote `meta.lastBuildFailure = null`, but `Ingeminator.rescheduleFailedBuildsForJob` reads it as `lastFailure.toMillis()` for backoff computation. Once auto-recovery runs every tick, that null deref would crash the scheduler pass before any new editor jobs could be scheduled — i.e. the fix would deadlock the very thing it was meant to unblock. Fixed by (a) writing `Timestamp.fromMillis(0)` instead of `null` in `resetFailureCount` and (b) guarding the Ingeminator with `lastBuildFailure ?? Timestamp.fromMillis(0)`. Defence in depth — the same null path was reachable from the existing admin reset endpoint.
2. **Indefinite retry churn.** A fundamentally broken build (e.g. an unbuildable editor/baseOs combination) would fail `maxFailuresPerBuild` (15) times, get auto-reset, fail another 15 times, get reset again, forever — burning Actions minutes and Docker Hub API quota with no escalation. Added `meta.recoveryCount` (tracked via `CiBuilds.incrementRecoveryCount`) and `Cleaner.maxRecoveryAttempts = 2`. After two recovery rounds the build is left at max retries and an alert goes to Discord asking for manual investigation.
3. **DockerHub / Firestore hammering.** The naive loop processed every maxed-out build for the latest repo every tick, with a DockerHub fetch per build. Aligned with the sibling cleaners by capping at `maxBuildsProcessedPerRun` (5) per tick; the rest are tagged `deferred:` in the returned summary and picked up next tick.

## Order of operations in `scheduleBuildsFromTheQueue`
1. `CiJobs.markJobsBeforeRepoVersionAsSuperseded` — old-repo jobs no longer block the failing-jobs queue
2. `Cleaner.recoverMaxedOutFailedBuilds` — maxed-out builds either become `published` (if on DockerHub) or have their failure count reset for the Ingeminator
3. `Scheduler` runs as before: base image, hub image, `ensureThereAreNoFailedJobs` (Ingeminator), then `buildLatestEditorImages`

Recovery runs *before* the Ingeminator on purpose, so by the time the Ingeminator iterates failed builds, no entry is at max retries.

## Firestore index
Added a composite index `(status ASC, buildInfo.repoVersion ASC)` on `ciBuilds` for the new `getMaxedOutFailedBuildsForRepoVersion` / `getAllForRepoVersion` queries. Without it the first production call would fail with a "create this index" URL.

## Known limitations / follow-ups
- Recovery only affects the **latest** repo version. Older-version failed builds are reachable via the existing admin endpoints; older-version jobs already get marked `superseded` so they do not block scheduling.
- Recovery only changes build-level state. The parent CiJob stays `'failed'` until all its builds reach `'published'`. If the failing-job count exceeds `maxToleratedFailures` (2), `ensureThereAreNoFailedJobs` still short-circuits before `buildLatestEditorImages`. This PR fixes the retry-exhausted sub-case; clearing backlogs of healthy-but-failing jobs is still the Ingeminator's responsibility.
- `specificTag` / `friendlyTag` written by `markBuildAsPublished` from recovery are `${baseOs}-${repoVersion}` and the major.minor of `repoVersion` respectively. These do not include the editor version / target platform. This matches the existing `healFailedBuildsAlreadyOnDockerHub` and `cleanUpBuildsThatDidntReportBack` cleaners — i.e. an existing inconsistency, worth a follow-up to normalise across all three call sites.
- `queueStatus` is now world-readable with no auth. Response includes job IDs, statuses and DockerHub digests; write paths (`resetFailedBuilds`, `retryBuild`) remain auth-gated. Intentional, called out here for visibility.

## Testing
- `yarn typecheck`