### PR TITLE
fix: mark parent job failed when build times out or is manually cleared

### DIFF
--- a/functions/src/logic/buildQueue/cleaner.ts
+++ b/functions/src/logic/buildQueue/cleaner.ts
@@ -16,6 +16,7 @@ export class Cleaner {
   public static async cleanUp(latestRepoVersion: string) {
     this.buildsProcessed = 0;
     await this.requeueActiveJobsWithoutBuilds();
+    await this.transitionStaleInProgressJobsToFailed();
     await this.recoverMaxedOutFailedBuilds(latestRepoVersion);
     await this.reconcileStartedBuildsThatMayHavePublished();
     await this.cleanUpBuildsThatDidntReportBack();
@@ -56,6 +57,40 @@ export class Cleaner {
       await CiJobs.resetJobToCreated(jobId);
       await Discord.sendAlert(
         `[Cleaner] Reset stale ${job.status} job "${jobId}" back to created because it had no build records after ${this.activeJobWithoutBuildsAfterMinutes} minutes.`,
+      );
+    }
+  }
+
+  /**
+   * An inProgress job whose builds have all finished (none are "started") is
+   * stuck — the job will never self-transition because only the build-report
+   * path calls markFailureForJob. Move these to "failed" so the Ingeminator
+   * can schedule retries and free up queue capacity for fresh jobs.
+   */
+  private static async transitionStaleInProgressJobsToFailed() {
+    const activeJobs = await CiJobs.getActiveJobs();
+    const staleThresholdMs = this.activeJobWithoutBuildsAfterMinutes * 60 * 1000;
+
+    for (const activeJob of activeJobs) {
+      if (this.buildsProcessed >= this.maxBuildsProcessedPerRun) return;
+
+      const { id: jobId, data: job } = activeJob;
+      const lastTouchedSeconds = job.modifiedDate?.seconds || job.addedDate?.seconds;
+      if (!lastTouchedSeconds) continue;
+
+      const ageMs = Date.now() - lastTouchedSeconds * 1000;
+      if (ageMs < staleThresholdMs) continue;
+
+      const hasBuilds = await CiBuilds.hasAnyBuildsForJob(jobId);
+      if (!hasBuilds) continue; // no builds at all — handled by requeueActiveJobsWithoutBuilds
+
+      const hasStartedBuilds = await CiBuilds.hasAnyStartedBuildsForJob(jobId);
+      if (hasStartedBuilds) continue; // at least one build is still running
+
+      this.buildsProcessed += 1;
+      await CiJobs.markFailureForJob(jobId);
+      await Discord.sendAlert(
+        `[Cleaner] Transitioned ${job.status} job "${jobId}" to failed: all its builds have settled with no started builds remaining.`,
       );
     }
   }
@@ -161,6 +196,7 @@ export class Cleaner {
         await CiBuilds.markBuildAsFailed(buildId, {
           reason: `[ManualCleanup] Build never reported back and image not found on DockerHub.`,
         });
+        await CiJobs.markFailureForJob(jobId);
         continue;
       }
 
@@ -315,6 +351,7 @@ export class Cleaner {
           await CiBuilds.markBuildAsFailed(buildId, {
             reason: markAsFailedMessage,
           });
+          await CiJobs.markFailureForJob(jobId);
 
           continue;
         }

--- a/functions/src/model/ciBuilds.ts
+++ b/functions/src/model/ciBuilds.ts
@@ -126,6 +126,17 @@ export class CiBuilds {
     return snapshot.docs.length > 0;
   };
 
+  public static hasAnyStartedBuildsForJob = async (jobId: string): Promise<boolean> => {
+    const snapshot = await db
+      .collection(CiBuilds.collection)
+      .where('relatedJobId', '==', jobId)
+      .where('status', '==', 'started')
+      .limit(1)
+      .get();
+
+    return snapshot.docs.length > 0;
+  };
+
   /**
    * Registers a new build or handles duplicate dispatches gracefully.
    * Returns the existing status if the build is already in progress or published,


### PR DESCRIPTION
## Summary

- `cleanUpBuildsThatDidntReportBack` marks a build `failed` after the 6-hour GitHub Actions timeout but never called `markFailureForJob`, leaving the parent job stuck in `inProgress`
- Same gap in `manualCleanUp`
- With `maxConcurrentJobs=9`, these ghost-inProgress jobs consumed all queue capacity — confirmed as the cause of the current blockage where 9 inProgress jobs with 9 failed builds were holding 53 created jobs from scheduling

**Three-part fix:**

1. `cleanUpBuildsThatDidntReportBack` — call `markFailureForJob` after marking build as failed so the Ingeminator picks it up next cron cycle
2. `manualCleanUp` — same fix for the manual path
3. `transitionStaleInProgressJobsToFailed` — new cleaner step that detects active jobs where all builds have settled (none are `started`) and transitions them to `failed`, unblocking capacity for jobs already stuck before this deploy

Adds `CiBuilds.hasAnyStartedBuildsForJob` to support the new cleaner step.

## Why it wasn't caught by PR #97

`requeueActiveJobsWithoutBuilds` (added in #97) only fires for jobs with **no build records at all**. The stuck jobs had build records — just failed ones — so they fell through every existing self-healing path.

## Test plan

- [ ] typecheck passes (`yarn typecheck`)
- [ ] Deploy and confirm the 9 currently-stuck inProgress jobs transition to `failed` on the next cleaner run
- [ ] Confirm the 53 `created` editor jobs begin scheduling once capacity is freed
- [ ] Simulate a future timeout: let a build go 6h without reporting, confirm cleaner marks both build and job as `failed`, and Ingeminator retries on the next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stale and stuck build jobs by properly marking them as failed when no active builds are detected, preventing jobs from remaining in an incomplete state indefinitely.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/game-ci/versioning-backend/pull/98)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->