### PR TITLE
[codex] fix Unity release fallback

### DIFF
--- a/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
+++ b/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
@@ -1,41 +1,96 @@
 import { EditorVersionInfo } from '../../model/editorVersionInfo';
 import { searchChangesets, SearchMode } from 'unity-changeset';
+import fetch from 'node-fetch';
 
 const unity_version_regex = /^(\d+)\.(\d+)\.(\d+)([a-zA-Z]+)(-?\d+)$/;
+const unity_whats_new_url = 'https://unity.com/releases/editor/whats-new';
+
+type UnityChangesetVersion = {
+  version: string;
+  changeset: string;
+};
+
+const toEditorVersionInfo = (unityVersion: UnityChangesetVersion): EditorVersionInfo | null => {
+  const match = RegExp(unity_version_regex).exec(unityVersion.version);
+  if (!match) {
+    return null;
+  }
+
+  const [_, major, minor, patch, lifecycle] = match;
+
+  if (lifecycle !== 'f' || Number(major) < 2017) {
+    return null;
+  }
+
+  return {
+    version: unityVersion.version,
+    changeSet: unityVersion.changeset,
+    major: Number(major),
+    minor: Number(minor),
+    patch,
+  } as EditorVersionInfo;
+};
+
+export const scrapeLatestOfficialUnityVersion = async (): Promise<EditorVersionInfo | null> => {
+  const response = await fetch(unity_whats_new_url, {
+    redirect: 'follow',
+    headers: {
+      'User-Agent': 'game-ci-versioning-backend/1.0',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unity release page returned ${response.status}`);
+  }
+
+  const html = await response.text();
+  const versionMatch = /Unity\s+(\d+\.\d+\.\d+f\d+)/.exec(html);
+  const escapedVersion = versionMatch?.[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const changesetMatch = versionMatch
+    ? new RegExp(`unityhub://${escapedVersion}/([a-f0-9]{12})`, 'i').exec(html) ||
+      /Changeset:\s*([a-f0-9]{12})/i.exec(html)
+    : null;
+
+  if (!versionMatch || !changesetMatch) {
+    return null;
+  }
+
+  return toEditorVersionInfo({
+    version: versionMatch[1],
+    changeset: changesetMatch[1],
+  });
+};
 
 export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
-  const unityVersions = await searchChangesets(SearchMode.Default);
-  const unityXltsVersions = await searchChangesets(SearchMode.XLTS);
+  const unityVersions: UnityChangesetVersion[] = (await searchChangesets(SearchMode.Default)).map(({ version, changeset }) => ({
+    version,
+    changeset,
+  }));
+  const unityXltsVersions: UnityChangesetVersion[] = (await searchChangesets(SearchMode.XLTS)).map(({ version, changeset }) => ({
+    version,
+    changeset,
+  }));
+  const latestOfficialVersion = await scrapeLatestOfficialUnityVersion();
 
   // Merge XLTS versions into main list, avoiding duplicates
   const existingVersions = new Set(unityVersions.map((v) => v.version));
   for (const xltsVersion of unityXltsVersions) {
     if (!existingVersions.has(xltsVersion.version)) {
       unityVersions.push(xltsVersion);
+      existingVersions.add(xltsVersion.version);
     }
+  }
+
+  if (latestOfficialVersion && !existingVersions.has(latestOfficialVersion.version)) {
+    unityVersions.push({
+      version: latestOfficialVersion.version,
+      changeset: latestOfficialVersion.changeSet,
+    });
   }
 
   if (unityVersions?.length > 0) {
     return unityVersions
-      .map((unityVersion) => {
-        const match = RegExp(unity_version_regex).exec(unityVersion.version);
-        if (match) {
-          const [_, major, minor, patch, lifecycle] = match;
-
-          if (lifecycle !== 'f' || Number(major) < 2017) {
-            return null;
-          }
-
-          return {
-            version: unityVersion.version,
-            changeSet: unityVersion.changeset,
-            major: Number(major),
-            minor: Number(minor),
-            patch,
-          } as EditorVersionInfo;
-        }
-        return null;
-      })
+      .map(toEditorVersionInfo)
       .filter((versionInfo): versionInfo is EditorVersionInfo => versionInfo !== null);
   }
 

--- a/functions/test/scrapeVersions.test.ts
+++ b/functions/test/scrapeVersions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { scrapeVersions } from '../src/logic/ingestUnityVersions/scrapeVersions';
+import { scrapeLatestOfficialUnityVersion, scrapeVersions } from '../src/logic/ingestUnityVersions/scrapeVersions';
 import { SearchMode } from 'unity-changeset';
+import fetch from 'node-fetch';
 
 // Mock the unity-changeset module
 vi.mock('unity-changeset', async () => {
@@ -11,11 +12,25 @@ vi.mock('unity-changeset', async () => {
   };
 });
 
+vi.mock('node-fetch', () => ({
+  default: vi.fn(),
+}));
+
 const { searchChangesets } = await import('unity-changeset');
+const mockedFetch = fetch as unknown as vi.MockedFunction<typeof fetch>;
+
+const mockOfficialUnityRelease = (html = '<h1>Unity 6000.4.10f1</h1><p>Changeset: feeafc12a938</p>') => {
+  mockedFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: async () => html,
+  } as any);
+};
 
 describe('scrapeVersions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockOfficialUnityRelease('');
   });
 
   it('should fetch both default and XLTS versions', async () => {
@@ -99,6 +114,60 @@ describe('scrapeVersions', () => {
         major: 2021,
         minor: 3,
         patch: '25',
+      }),
+    );
+  });
+
+  it('should merge the latest official Unity release when unity-changeset is stale', async () => {
+    mockOfficialUnityRelease();
+    const mockDefaultVersions = [
+      {
+        version: '6000.4.7f1',
+        changeset: 'f3c3c4248748',
+      },
+    ];
+
+    (searchChangesets as vi.MockedFunction<any>).mockImplementation(async (mode: SearchMode) => {
+      if (mode === SearchMode.Default) {
+        return mockDefaultVersions;
+      }
+      return [];
+    });
+
+    const result = await scrapeVersions();
+
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        version: '6000.4.10f1',
+        changeSet: 'feeafc12a938',
+        major: 6000,
+        minor: 4,
+        patch: '10',
+      }),
+    );
+  });
+
+  it('should parse the latest official Unity release page', async () => {
+    mockOfficialUnityRelease('<h1>Unity 6000.4.10f1</h1><div>Changeset: feeafc12a938</div>');
+
+    await expect(scrapeLatestOfficialUnityVersion()).resolves.toEqual(
+      expect.objectContaining({
+        version: '6000.4.10f1',
+        changeSet: 'feeafc12a938',
+        major: 6000,
+        minor: 4,
+        patch: '10',
+      }),
+    );
+  });
+
+  it('should parse the Unity Hub install URL from the official release page', async () => {
+    mockOfficialUnityRelease('<h1>Unity 6000.4.10f1</h1><a href="unityhub://6000.4.10f1/feeafc12a938">Install</a>');
+
+    await expect(scrapeLatestOfficialUnityVersion()).resolves.toEqual(
+      expect.objectContaining({
+        version: '6000.4.10f1',
+        changeSet: 'feeafc12a938',
       }),
     );
   });


### PR DESCRIPTION
## Summary
- add an official Unity release-page fallback when `unity-changeset` lags behind Unity releases
- parse both `Changeset:` markup and Unity Hub install URLs for the latest release changeset
- cover stale catalog ingestion for Unity 6000.4.10f1 / feeafc12a938

## Testing
- corepack yarn workspace functions test:run test/scrapeVersions.test.ts
- corepack yarn workspace functions typecheck:tsc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced detection and integration of the latest official Unity version releases
  * Improved consolidation of version data from multiple sources with refined deduplication logic

* **Tests**
  * Added comprehensive test coverage for version scraping, official release page parsing, and version extraction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->