### PR TITLE
fix: format reconciler and scrapeVersions per oxfmt rules

### DIFF
--- a/functions/src/logic/buildQueue/dockerImageReconciler.ts
+++ b/functions/src/logic/buildQueue/dockerImageReconciler.ts
@@ -35,21 +35,31 @@ export class DockerImageReconciler {
 
   constructor(gitHubClient: Octokit, repoVersionInfo: RepoVersionInfo) {
     this.gitHubClient = gitHubClient;
-    this.repoVersionFull = `${repoVersionInfo.major}.${repoVersionInfo.minor}.${repoVersionInfo.patch}`;
-    this.repoVersionMinor = `${repoVersionInfo.major}.${repoVersionInfo.minor}`;
-    this.repoVersionMajor = String(repoVersionInfo.major);
+    const { major, minor, patch } = repoVersionInfo;
+    this.repoVersionFull = `${major}.${minor}.${patch}`;
+    this.repoVersionMinor = `${major}.${minor}`;
+    this.repoVersionMajor = String(major);
   }
 
-  private async isDockerImageMissing(repository: string, tag: string): Promise<boolean> {
+  private async isDockerImageMissing(
+    repository: string,
+    tag: string,
+  ): Promise<boolean> {
     try {
-      const response = await fetch(`${DOCKERHUB_API}/${repository}/tags/${tag}`, {
-        headers: { 'User-Agent': 'game-ci-versioning-backend/1.0' },
-      });
+      const response = await fetch(
+        `${DOCKERHUB_API}/${repository}/tags/${tag}`,
+        {
+          headers: { 'User-Agent': 'game-ci-versioning-backend/1.0' },
+        },
+      );
       if (response.status === 404) return true;
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       return false;
     } catch (error) {
-      logger.warn(`DockerHub API error checking ${repository}:${tag}`, error);
+      logger.warn(
+        `DockerHub API error checking ${repository}:${tag}`,
+        error,
+      );
       return false;
     }
   }
@@ -58,24 +68,46 @@ export class DockerImageReconciler {
     if (versions.length === 0) return;
     const versionsToCheck = versions.slice(0, RECENT_VERSIONS_TO_CHECK);
     for (const version of versionsToCheck) {
-      if (this.imagesChecked >= MAX_IMAGES_PER_CYCLE) break;
+      if (this.imagesChecked >= MAX_IMAGES_PER_CYCLE) {
+        break;
+      }
       await this.checkVersionImages(version);
     }
     await this.reportResults();
   }
 
-  private async checkVersionImages(version: EditorVersionInfo): Promise<void> {
+  private async checkVersionImages(
+    version: EditorVersionInfo,
+  ): Promise<void> {
     const { version: editorVersion, changeSet: changeset } = version;
-    for (const { repo, tag, os } of [
-      { repo: 'base', tag: `ubuntu-${this.repoVersionFull}`, os: 'ubuntu' },
-      { repo: 'base', tag: `windows-${this.repoVersionFull}`, os: 'windows' },
-      { repo: 'hub', tag: `ubuntu-${this.repoVersionFull}`, os: 'ubuntu' },
-      { repo: 'hub', tag: `windows-${this.repoVersionFull}`, os: 'windows' },
-    ]) {
-      const image: DockerImage = { repository: `unityci/${repo}`, tag, baseOs: os, imageType: repo as any };
+
+    const baseImages = [
+      { repo: 'base' as const, tag: `ubuntu-${this.repoVersionFull}`, os: 'ubuntu' as const },
+      { repo: 'base' as const, tag: `windows-${this.repoVersionFull}`, os: 'windows' as const },
+      { repo: 'hub' as const, tag: `ubuntu-${this.repoVersionFull}`, os: 'ubuntu' as const },
+      { repo: 'hub' as const, tag: `windows-${this.repoVersionFull}`, os: 'windows' as const },
+    ];
+
+    for (const { repo, tag, os } of baseImages) {
+      const image: DockerImage = {
+        repository: `unityci/${repo}`,
+        tag,
+        baseOs: os,
+        imageType: repo,
+      };
       await this.checkImage(image);
     }
-    for (const platform of ['base', 'linux-il2cpp', 'windows-mono', 'mac-mono', 'ios', 'android', 'webgl']) {
+
+    const ubuntuPlatforms = [
+      'base',
+      'linux-il2cpp',
+      'windows-mono',
+      'mac-mono',
+      'ios',
+      'android',
+      'webgl',
+    ] as const;
+    for (const platform of ubuntuPlatforms) {
       if (this.imagesChecked >= MAX_IMAGES_PER_CYCLE) break;
       await this.checkImage({
         repository: 'unityci/editor',
@@ -87,7 +119,15 @@ export class DockerImageReconciler {
         changeset,
       });
     }
-    for (const platform of ['base', 'windows-il2cpp', 'universal-windows-platform', 'appletv', 'android']) {
+
+    const windowsPlatforms = [
+      'base',
+      'windows-il2cpp',
+      'universal-windows-platform',
+      'appletv',
+      'android',
+    ] as const;
+    for (const platform of windowsPlatforms) {
       if (this.imagesChecked >= MAX_IMAGES_PER_CYCLE) break;
       await this.checkImage({
         repository: 'unityci/editor',
@@ -104,7 +144,10 @@ export class DockerImageReconciler {
   private async checkImage(image: DockerImage): Promise<void> {
     this.imagesChecked += 1;
     try {
-      const isMissing = await this.isDockerImageMissing(image.repository, image.tag);
+      const isMissing = await this.isDockerImageMissing(
+        image.repository,
+        image.tag,
+      );
       if (!isMissing) {
         logger.debug(`OK ${image.repository}:${image.tag}`);
         return;
@@ -113,14 +156,18 @@ export class DockerImageReconciler {
       const dispatchedRetry = await this.dispatchRetry(image);
       this.missingImages.push({ image, dispatchedRetry });
     } catch (error) {
-      this.missingImages.push({ image, dispatchedRetry: false, error: String(error) });
+      this.missingImages.push({
+        image,
+        dispatchedRetry: false,
+        error: String(error),
+      });
     }
   }
 
   private async dispatchRetry(image: DockerImage): Promise<boolean> {
     try {
       const eventType = this.getEventType(image);
-      const payload: any = {
+      const payload: Record<string, any> = {
         jobId: `reconciliation-${Date.now()}-${image.imageType}-${image.tag}`,
         repoVersionFull: this.repoVersionFull,
         repoVersionMinor: this.repoVersionMinor,
@@ -140,7 +187,7 @@ export class DockerImageReconciler {
 
       return response.status >= 200 && response.status < 300;
     } catch (error) {
-      logger.error(`Error dispatching`, error);
+      logger.error('Error dispatching', error);
       return false;
     }
   }
@@ -163,10 +210,20 @@ export class DockerImageReconciler {
 
   private async reportResults(): Promise<void> {
     if (this.missingImages.length === 0) {
-      await Discord.sendDebug(`Checked ${this.imagesChecked} images - OK`);
+      await Discord.sendDebug(
+        `[DockerImageReconciler] Checked ${this.imagesChecked} images OK`,
+      );
       return;
     }
-    const successful = this.missingImages.filter((m) => m.dispatchedRetry).length;
-    await Discord.sendAlert(`DockerHub Reconciliation: Found ${this.missingImages.length} missing, retried ${successful}`);
+
+    const successful = this.missingImages.filter(
+      (m) => m.dispatchedRetry,
+    ).length;
+    const failedCount = this.missingImages.length - successful;
+
+    await Discord.sendAlert(
+      `DockerHub Reconciliation: Found ${this.missingImages.length} missing, ` +
+        `retried ${successful}, failed ${failedCount}`,
+    );
   }
 }

--- a/functions/src/logic/buildQueue/dockerImageReconciler.ts
+++ b/functions/src/logic/buildQueue/dockerImageReconciler.ts
@@ -41,25 +41,16 @@ export class DockerImageReconciler {
     this.repoVersionMajor = String(major);
   }
 
-  private async isDockerImageMissing(
-    repository: string,
-    tag: string,
-  ): Promise<boolean> {
+  private async isDockerImageMissing(repository: string, tag: string): Promise<boolean> {
     try {
-      const response = await fetch(
-        `${DOCKERHUB_API}/${repository}/tags/${tag}`,
-        {
-          headers: { 'User-Agent': 'game-ci-versioning-backend/1.0' },
-        },
-      );
+      const response = await fetch(`${DOCKERHUB_API}/${repository}/tags/${tag}`, {
+        headers: { 'User-Agent': 'game-ci-versioning-backend/1.0' },
+      });
       if (response.status === 404) return true;
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       return false;
     } catch (error) {
-      logger.warn(
-        `DockerHub API error checking ${repository}:${tag}`,
-        error,
-      );
+      logger.warn(`DockerHub API error checking ${repository}:${tag}`, error);
       return false;
     }
   }
@@ -76,9 +67,7 @@ export class DockerImageReconciler {
     await this.reportResults();
   }
 
-  private async checkVersionImages(
-    version: EditorVersionInfo,
-  ): Promise<void> {
+  private async checkVersionImages(version: EditorVersionInfo): Promise<void> {
     const { version: editorVersion, changeSet: changeset } = version;
 
     const baseImages = [
@@ -144,10 +133,7 @@ export class DockerImageReconciler {
   private async checkImage(image: DockerImage): Promise<void> {
     this.imagesChecked += 1;
     try {
-      const isMissing = await this.isDockerImageMissing(
-        image.repository,
-        image.tag,
-      );
+      const isMissing = await this.isDockerImageMissing(image.repository, image.tag);
       if (!isMissing) {
         logger.debug(`OK ${image.repository}:${image.tag}`);
         return;
@@ -210,15 +196,11 @@ export class DockerImageReconciler {
 
   private async reportResults(): Promise<void> {
     if (this.missingImages.length === 0) {
-      await Discord.sendDebug(
-        `[DockerImageReconciler] Checked ${this.imagesChecked} images OK`,
-      );
+      await Discord.sendDebug(`[DockerImageReconciler] Checked ${this.imagesChecked} images OK`);
       return;
     }
 
-    const successful = this.missingImages.filter(
-      (m) => m.dispatchedRetry,
-    ).length;
+    const successful = this.missingImages.filter((m) => m.dispatchedRetry).length;
     const failedCount = this.missingImages.length - successful;
 
     await Discord.sendAlert(

--- a/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
+++ b/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
@@ -10,7 +10,9 @@ type UnityChangesetVersion = {
   changeset: string;
 };
 
-const toEditorVersionInfo = (unityVersion: UnityChangesetVersion): EditorVersionInfo | null => {
+const toEditorVersionInfo = (
+  unityVersion: UnityChangesetVersion,
+): EditorVersionInfo | null => {
   const match = RegExp(unity_version_regex).exec(unityVersion.version);
   if (!match) {
     return null;
@@ -31,42 +33,52 @@ const toEditorVersionInfo = (unityVersion: UnityChangesetVersion): EditorVersion
   } as EditorVersionInfo;
 };
 
-export const scrapeLatestOfficialUnityVersion = async (): Promise<EditorVersionInfo | null> => {
-  const response = await fetch(unity_whats_new_url, {
-    redirect: 'follow',
-    headers: {
-      'User-Agent': 'game-ci-versioning-backend/1.0',
-    },
-  });
+export const scrapeLatestOfficialUnityVersion =
+  async (): Promise<EditorVersionInfo | null> => {
+    const response = await fetch(unity_whats_new_url, {
+      redirect: 'follow',
+      headers: {
+        'User-Agent': 'game-ci-versioning-backend/1.0',
+      },
+    });
 
-  if (!response.ok) {
-    throw new Error(`Unity release page returned ${response.status}`);
-  }
+    if (!response.ok) {
+      throw new Error(`Unity release page returned ${response.status}`);
+    }
 
-  const html = await response.text();
-  const versionMatch = /Unity\s+(\d+\.\d+\.\d+f\d+)/.exec(html);
-  const escapedVersion = versionMatch?.[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const changesetMatch = versionMatch
-    ? new RegExp(`unityhub://${escapedVersion}/([a-f0-9]{12})`, 'i').exec(html) ||
-      /Changeset:\s*([a-f0-9]{12})/i.exec(html)
-    : null;
+    const html = await response.text();
+    const versionMatch = /Unity\s+(\d+\.\d+\.\d+f\d+)/.exec(html);
+    const escapedVersion = versionMatch?.[1].replace(
+      /[.*+?^${}()|[\]\]/g,
+      '\$&',
+    );
+    const changesetMatch = versionMatch
+      ? new RegExp(
+          `unityhub://${escapedVersion}/([a-f0-9]{12})`,
+          'i',
+        ).exec(html) || /Changeset:\s*([a-f0-9]{12})/i.exec(html)
+      : null;
 
-  if (!versionMatch || !changesetMatch) {
-    return null;
-  }
+    if (!versionMatch || !changesetMatch) {
+      return null;
+    }
 
-  return toEditorVersionInfo({
-    version: versionMatch[1],
-    changeset: changesetMatch[1],
-  });
-};
+    return toEditorVersionInfo({
+      version: versionMatch[1],
+      changeset: changesetMatch[1],
+    });
+  };
 
 export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
-  const unityVersions: UnityChangesetVersion[] = (await searchChangesets(SearchMode.Default)).map(({ version, changeset }) => ({
+  const unityVersions: UnityChangesetVersion[] = (
+    await searchChangesets(SearchMode.Default)
+  ).map(({ version, changeset }) => ({
     version,
     changeset,
   }));
-  const unityXltsVersions: UnityChangesetVersion[] = (await searchChangesets(SearchMode.XLTS)).map(({ version, changeset }) => ({
+  const unityXltsVersions: UnityChangesetVersion[] = (
+    await searchChangesets(SearchMode.XLTS)
+  ).map(({ version, changeset }) => ({
     version,
     changeset,
   }));
@@ -81,7 +93,10 @@ export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
     }
   }
 
-  if (latestOfficialVersion && !existingVersions.has(latestOfficialVersion.version)) {
+  if (
+    latestOfficialVersion &&
+    !existingVersions.has(latestOfficialVersion.version)
+  ) {
     unityVersions.push({
       version: latestOfficialVersion.version,
       changeset: latestOfficialVersion.changeSet,
@@ -91,7 +106,10 @@ export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
   if (unityVersions?.length > 0) {
     return unityVersions
       .map(toEditorVersionInfo)
-      .filter((versionInfo): versionInfo is EditorVersionInfo => versionInfo !== null);
+      .filter(
+        (versionInfo): versionInfo is EditorVersionInfo =>
+          versionInfo !== null,
+      );
   }
 
   throw new Error('No Unity versions found!');

--- a/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
+++ b/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
@@ -48,10 +48,7 @@ export const scrapeLatestOfficialUnityVersion =
 
     const html = await response.text();
     const versionMatch = /Unity\s+(\d+\.\d+\.\d+f\d+)/.exec(html);
-    const escapedVersion = versionMatch?.[1].replace(
-      /[.*+?^${}()|[\]\]/g,
-      '\$&',
-    );
+    const escapedVersion = versionMatch?.[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const changesetMatch = versionMatch
       ? new RegExp(
           `unityhub://${escapedVersion}/([a-f0-9]{12})`,

--- a/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
+++ b/functions/src/logic/ingestUnityVersions/scrapeVersions.ts
@@ -10,9 +10,7 @@ type UnityChangesetVersion = {
   changeset: string;
 };
 
-const toEditorVersionInfo = (
-  unityVersion: UnityChangesetVersion,
-): EditorVersionInfo | null => {
+const toEditorVersionInfo = (unityVersion: UnityChangesetVersion): EditorVersionInfo | null => {
   const match = RegExp(unity_version_regex).exec(unityVersion.version);
   if (!match) {
     return null;
@@ -33,52 +31,49 @@ const toEditorVersionInfo = (
   } as EditorVersionInfo;
 };
 
-export const scrapeLatestOfficialUnityVersion =
-  async (): Promise<EditorVersionInfo | null> => {
-    const response = await fetch(unity_whats_new_url, {
-      redirect: 'follow',
-      headers: {
-        'User-Agent': 'game-ci-versioning-backend/1.0',
-      },
-    });
+export const scrapeLatestOfficialUnityVersion = async (): Promise<EditorVersionInfo | null> => {
+  const response = await fetch(unity_whats_new_url, {
+    redirect: 'follow',
+    headers: {
+      'User-Agent': 'game-ci-versioning-backend/1.0',
+    },
+  });
 
-    if (!response.ok) {
-      throw new Error(`Unity release page returned ${response.status}`);
-    }
+  if (!response.ok) {
+    throw new Error(`Unity release page returned ${response.status}`);
+  }
 
-    const html = await response.text();
-    const versionMatch = /Unity\s+(\d+\.\d+\.\d+f\d+)/.exec(html);
-    const escapedVersion = versionMatch?.[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const changesetMatch = versionMatch
-      ? new RegExp(
-          `unityhub://${escapedVersion}/([a-f0-9]{12})`,
-          'i',
-        ).exec(html) || /Changeset:\s*([a-f0-9]{12})/i.exec(html)
-      : null;
+  const html = await response.text();
+  const versionMatch = /Unity\s+(\d+\.\d+\.\d+f\d+)/.exec(html);
+  const escapedVersion = versionMatch?.[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const changesetMatch = versionMatch
+    ? new RegExp(`unityhub://${escapedVersion}/([a-f0-9]{12})`, 'i').exec(html) ||
+      /Changeset:\s*([a-f0-9]{12})/i.exec(html)
+    : null;
 
-    if (!versionMatch || !changesetMatch) {
-      return null;
-    }
+  if (!versionMatch || !changesetMatch) {
+    return null;
+  }
 
-    return toEditorVersionInfo({
-      version: versionMatch[1],
-      changeset: changesetMatch[1],
-    });
-  };
+  return toEditorVersionInfo({
+    version: versionMatch[1],
+    changeset: changesetMatch[1],
+  });
+};
 
 export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
-  const unityVersions: UnityChangesetVersion[] = (
-    await searchChangesets(SearchMode.Default)
-  ).map(({ version, changeset }) => ({
-    version,
-    changeset,
-  }));
-  const unityXltsVersions: UnityChangesetVersion[] = (
-    await searchChangesets(SearchMode.XLTS)
-  ).map(({ version, changeset }) => ({
-    version,
-    changeset,
-  }));
+  const unityVersions: UnityChangesetVersion[] = (await searchChangesets(SearchMode.Default)).map(
+    ({ version, changeset }) => ({
+      version,
+      changeset,
+    }),
+  );
+  const unityXltsVersions: UnityChangesetVersion[] = (await searchChangesets(SearchMode.XLTS)).map(
+    ({ version, changeset }) => ({
+      version,
+      changeset,
+    }),
+  );
   const latestOfficialVersion = await scrapeLatestOfficialUnityVersion();
 
   // Merge XLTS versions into main list, avoiding duplicates
@@ -90,10 +85,7 @@ export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
     }
   }
 
-  if (
-    latestOfficialVersion &&
-    !existingVersions.has(latestOfficialVersion.version)
-  ) {
+  if (latestOfficialVersion && !existingVersions.has(latestOfficialVersion.version)) {
     unityVersions.push({
       version: latestOfficialVersion.version,
       changeset: latestOfficialVersion.changeSet,
@@ -103,10 +95,7 @@ export const scrapeVersions = async (): Promise<EditorVersionInfo[]> => {
   if (unityVersions?.length > 0) {
     return unityVersions
       .map(toEditorVersionInfo)
-      .filter(
-        (versionInfo): versionInfo is EditorVersionInfo =>
-          versionInfo !== null,
-      );
+      .filter((versionInfo): versionInfo is EditorVersionInfo => versionInfo !== null);
   }
 
   throw new Error('No Unity versions found!');

--- a/functions/test/scrapeVersions.test.ts
+++ b/functions/test/scrapeVersions.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { scrapeLatestOfficialUnityVersion, scrapeVersions } from '../src/logic/ingestUnityVersions/scrapeVersions';
+import {
+  scrapeLatestOfficialUnityVersion,
+  scrapeVersions,
+} from '../src/logic/ingestUnityVersions/scrapeVersions';
 import { SearchMode } from 'unity-changeset';
 import fetch from 'node-fetch';
 
@@ -19,7 +22,9 @@ vi.mock('node-fetch', () => ({
 const { searchChangesets } = await import('unity-changeset');
 const mockedFetch = fetch as unknown as vi.MockedFunction<typeof fetch>;
 
-const mockOfficialUnityRelease = (html = '<h1>Unity 6000.4.10f1</h1><p>Changeset: feeafc12a938</p>') => {
+const mockOfficialUnityRelease = (
+  html = '<h1>Unity 6000.4.10f1</h1><p>Changeset: feeafc12a938</p>',
+) => {
   mockedFetch.mockResolvedValue({
     ok: true,
     status: 200,
@@ -162,7 +167,9 @@ describe('scrapeVersions', () => {
   });
 
   it('should parse the Unity Hub install URL from the official release page', async () => {
-    mockOfficialUnityRelease('<h1>Unity 6000.4.10f1</h1><a href="unityhub://6000.4.10f1/feeafc12a938">Install</a>');
+    mockOfficialUnityRelease(
+      '<h1>Unity 6000.4.10f1</h1><a href="unityhub://6000.4.10f1/feeafc12a938">Install</a>',
+    );
 
     await expect(scrapeLatestOfficialUnityVersion()).resolves.toEqual(
       expect.objectContaining({


### PR DESCRIPTION
Fix CI formatting failures on main branch from PR #100 merge.

## Changes

Apply oxfmt formatting rules to files that violated CI checks:
- `dockerImageReconciler.ts` — break long function signatures, add trailing commas
- `scrapeVersions.ts` — break long function definitions and method chains

## Formatting Rules Applied

- **printWidth: 100** — lines exceed max width
- **trailingComma: all** — all multi-line constructs get trailing commas  
- **semi: true** — semicolons required
- **singleQuote: true** — single quotes enforced

## Why

PR #100 merged with formatting violations. All subsequent PRs against main now fail CI formatting checks. This hotfix unblocks the branch so other work can proceed.