### PR TITLE
feat: incremental DockerHub reconciliation with cursor and cooldowns

### DIFF
--- a/functions/src/logic/buildQueue/dockerImageReconciler.ts
+++ b/functions/src/logic/buildQueue/dockerImageReconciler.ts
@@ -6,13 +6,30 @@ import { EditorVersionInfo } from '../../model/editorVersionInfo';
 import { RepoVersionInfo } from '../../model/repoVersionInfo';
 
 const DOCKERHUB_API = 'https://hub.docker.com/v2/repositories';
-const MAX_IMAGES_PER_CYCLE = 20;
-const RECENT_VERSIONS_TO_CHECK = 5;
+const TAG_PAGE_SIZE = 100;
+const MAX_TAG_PAGES = 50;
+const MAX_RETRIES_PER_CYCLE = 30;
+const UBUNTU_PLATFORMS = [
+  'base',
+  'linux-il2cpp',
+  'windows-mono',
+  'mac-mono',
+  'ios',
+  'android',
+  'webgl',
+] as const;
+const WINDOWS_PLATFORMS = [
+  'base',
+  'windows-il2cpp',
+  'universal-windows-platform',
+  'appletv',
+  'android',
+] as const;
 
 interface DockerImage {
   repository: string;
   tag: string;
-  baseOs: string;
+  baseOs: 'ubuntu' | 'windows';
   imageType: 'base' | 'hub' | 'editor';
   targetPlatform?: string;
   editorVersion?: string;
@@ -30,8 +47,8 @@ export class DockerImageReconciler {
   private repoVersionFull: string;
   private repoVersionMinor: string;
   private repoVersionMajor: string;
-  private imagesChecked = 0;
   private missingImages: MissingImage[] = [];
+  private retriesDispatched = 0;
 
   constructor(gitHubClient: Octokit, repoVersionInfo: RepoVersionInfo) {
     this.gitHubClient = gitHubClient;
@@ -41,120 +58,137 @@ export class DockerImageReconciler {
     this.repoVersionMajor = String(major);
   }
 
-  private async isDockerImageMissing(repository: string, tag: string): Promise<boolean> {
-    try {
-      const response = await fetch(`${DOCKERHUB_API}/${repository}/tags/${tag}`, {
-        headers: { 'User-Agent': 'game-ci-versioning-backend/1.0' },
-      });
-      if (response.status === 404) return true;
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      return false;
-    } catch (error) {
-      logger.warn(`DockerHub API error checking ${repository}:${tag}`, error);
-      return false;
-    }
-  }
-
   async reconcileEditorImages(versions: EditorVersionInfo[]): Promise<void> {
-    if (versions.length === 0) return;
-    const versionsToCheck = versions.slice(0, RECENT_VERSIONS_TO_CHECK);
-    for (const version of versionsToCheck) {
-      if (this.imagesChecked >= MAX_IMAGES_PER_CYCLE) {
+    if (versions.length === 0) {
+      return;
+    }
+
+    const [baseTags, hubTags, editorTags] = await Promise.all([
+      this.fetchExistingTags('unityci/base'),
+      this.fetchExistingTags('unityci/hub'),
+      this.fetchExistingTags('unityci/editor'),
+    ]);
+
+    const expectedImages = this.computeExpectedImages(versions);
+    const tagSetByRepo: Record<string, Set<string>> = {
+      'unityci/base': baseTags,
+      'unityci/hub': hubTags,
+      'unityci/editor': editorTags,
+    };
+
+    for (const image of expectedImages) {
+      if (this.retriesDispatched >= MAX_RETRIES_PER_CYCLE) {
         break;
       }
-      await this.checkVersionImages(version);
+      const existing = tagSetByRepo[image.repository];
+      if (existing.has(image.tag)) {
+        continue;
+      }
+      const dispatchedRetry = await this.dispatchRetry(image);
+      if (dispatchedRetry) {
+        this.retriesDispatched += 1;
+      }
+      this.missingImages.push({ image, dispatchedRetry });
     }
-    await this.reportResults();
+
+    await this.reportResults(expectedImages.length);
   }
 
-  private async checkVersionImages(version: EditorVersionInfo): Promise<void> {
-    const { version: editorVersion, changeSet: changeset } = version;
+  private async fetchExistingTags(repository: string): Promise<Set<string>> {
+    const tags = new Set<string>();
+    let nextUrl: string | null =
+      `${DOCKERHUB_API}/${repository}/tags?page_size=${TAG_PAGE_SIZE}&name=${this.repoVersionFull}`;
+    let pagesFetched = 0;
 
-    const baseImages = [
-      { repo: 'base' as const, tag: `ubuntu-${this.repoVersionFull}`, os: 'ubuntu' as const },
-      { repo: 'base' as const, tag: `windows-${this.repoVersionFull}`, os: 'windows' as const },
-      { repo: 'hub' as const, tag: `ubuntu-${this.repoVersionFull}`, os: 'ubuntu' as const },
-      { repo: 'hub' as const, tag: `windows-${this.repoVersionFull}`, os: 'windows' as const },
+    while (nextUrl && pagesFetched < MAX_TAG_PAGES) {
+      try {
+        const response = await fetch(nextUrl, {
+          headers: { 'User-Agent': 'game-ci-versioning-backend/1.0' },
+        });
+        if (!response.ok) {
+          logger.warn(`DockerHub list tags failed for ${repository}: HTTP ${response.status}`);
+          break;
+        }
+        const body = (await response.json()) as {
+          results?: { name: string }[];
+          next?: string | null;
+        };
+        for (const result of body.results ?? []) {
+          tags.add(result.name);
+        }
+        nextUrl = body.next ?? null;
+        pagesFetched += 1;
+      } catch (error) {
+        logger.warn(`DockerHub list tags error for ${repository}`, error);
+        break;
+      }
+    }
+
+    return tags;
+  }
+
+  private computeExpectedImages(versions: EditorVersionInfo[]): DockerImage[] {
+    const expected: DockerImage[] = [
+      {
+        repository: 'unityci/base',
+        tag: `ubuntu-${this.repoVersionFull}`,
+        baseOs: 'ubuntu',
+        imageType: 'base',
+      },
+      {
+        repository: 'unityci/base',
+        tag: `windows-${this.repoVersionFull}`,
+        baseOs: 'windows',
+        imageType: 'base',
+      },
+      {
+        repository: 'unityci/hub',
+        tag: `ubuntu-${this.repoVersionFull}`,
+        baseOs: 'ubuntu',
+        imageType: 'hub',
+      },
+      {
+        repository: 'unityci/hub',
+        tag: `windows-${this.repoVersionFull}`,
+        baseOs: 'windows',
+        imageType: 'hub',
+      },
     ];
 
-    for (const { repo, tag, os } of baseImages) {
-      const image: DockerImage = {
-        repository: `unityci/${repo}`,
-        tag,
-        baseOs: os,
-        imageType: repo,
-      };
-      await this.checkImage(image);
-    }
-
-    const ubuntuPlatforms = [
-      'base',
-      'linux-il2cpp',
-      'windows-mono',
-      'mac-mono',
-      'ios',
-      'android',
-      'webgl',
-    ] as const;
-    for (const platform of ubuntuPlatforms) {
-      if (this.imagesChecked >= MAX_IMAGES_PER_CYCLE) break;
-      await this.checkImage({
-        repository: 'unityci/editor',
-        tag: `ubuntu-${editorVersion}-${platform}-${this.repoVersionFull}`,
-        baseOs: 'ubuntu',
-        imageType: 'editor',
-        targetPlatform: platform,
-        editorVersion,
-        changeset,
-      });
-    }
-
-    const windowsPlatforms = [
-      'base',
-      'windows-il2cpp',
-      'universal-windows-platform',
-      'appletv',
-      'android',
-    ] as const;
-    for (const platform of windowsPlatforms) {
-      if (this.imagesChecked >= MAX_IMAGES_PER_CYCLE) break;
-      await this.checkImage({
-        repository: 'unityci/editor',
-        tag: `windows-${editorVersion}-${platform}-${this.repoVersionFull}`,
-        baseOs: 'windows',
-        imageType: 'editor',
-        targetPlatform: platform,
-        editorVersion,
-        changeset,
-      });
-    }
-  }
-
-  private async checkImage(image: DockerImage): Promise<void> {
-    this.imagesChecked += 1;
-    try {
-      const isMissing = await this.isDockerImageMissing(image.repository, image.tag);
-      if (!isMissing) {
-        logger.debug(`OK ${image.repository}:${image.tag}`);
-        return;
+    for (const version of versions) {
+      const { version: editorVersion, changeSet: changeset } = version;
+      for (const platform of UBUNTU_PLATFORMS) {
+        expected.push({
+          repository: 'unityci/editor',
+          tag: `ubuntu-${editorVersion}-${platform}-${this.repoVersionFull}`,
+          baseOs: 'ubuntu',
+          imageType: 'editor',
+          targetPlatform: platform,
+          editorVersion,
+          changeset,
+        });
       }
-      logger.warn(`Missing: ${image.repository}:${image.tag}`);
-      const dispatchedRetry = await this.dispatchRetry(image);
-      this.missingImages.push({ image, dispatchedRetry });
-    } catch (error) {
-      this.missingImages.push({
-        image,
-        dispatchedRetry: false,
-        error: String(error),
-      });
+      for (const platform of WINDOWS_PLATFORMS) {
+        expected.push({
+          repository: 'unityci/editor',
+          tag: `windows-${editorVersion}-${platform}-${this.repoVersionFull}`,
+          baseOs: 'windows',
+          imageType: 'editor',
+          targetPlatform: platform,
+          editorVersion,
+          changeset,
+        });
+      }
     }
+
+    return expected;
   }
 
   private async dispatchRetry(image: DockerImage): Promise<boolean> {
     try {
       const eventType = this.getEventType(image);
-      const payload: Record<string, any> = {
-        jobId: `reconciliation-${Date.now()}-${image.imageType}-${image.tag}`,
+      const payload: Record<string, unknown> = {
+        jobId: `reconciliation-${image.imageType}-${image.tag}`,
         repoVersionFull: this.repoVersionFull,
         repoVersionMinor: this.repoVersionMinor,
         repoVersionMajor: this.repoVersionMajor,
@@ -173,7 +207,7 @@ export class DockerImageReconciler {
 
       return response.status >= 200 && response.status < 300;
     } catch (error) {
-      logger.error('Error dispatching', error);
+      logger.error(`Error dispatching retry for ${image.tag}`, error);
       return false;
     }
   }
@@ -194,18 +228,23 @@ export class DockerImageReconciler {
       : GitHubWorkflow.eventTypes.retryWindowsEditorImage;
   }
 
-  private async reportResults(): Promise<void> {
+  private async reportResults(expectedCount: number): Promise<void> {
     if (this.missingImages.length === 0) {
-      await Discord.sendDebug(`[DockerImageReconciler] Checked ${this.imagesChecked} images OK`);
+      await Discord.sendDebug(
+        `[DockerImageReconciler] Verified ${expectedCount} expected images, all present`,
+      );
       return;
     }
 
     const successful = this.missingImages.filter((m) => m.dispatchedRetry).length;
-    const failedCount = this.missingImages.length - successful;
+    const failed = this.missingImages.length - successful;
 
     await Discord.sendAlert(
-      `DockerHub Reconciliation: Found ${this.missingImages.length} missing, ` +
-        `retried ${successful}, failed ${failedCount}`,
+      `DockerHub Reconciliation: ${this.missingImages.length} missing of ${expectedCount} expected; ` +
+        `retried ${successful}, failed ${failed}` +
+        (this.retriesDispatched >= MAX_RETRIES_PER_CYCLE
+          ? ` (capped at ${MAX_RETRIES_PER_CYCLE} retries; remaining will retry next cycle)`
+          : ''),
     );
   }
 }

--- a/functions/src/logic/buildQueue/dockerImageReconciler.ts
+++ b/functions/src/logic/buildQueue/dockerImageReconciler.ts
@@ -4,11 +4,17 @@ import { Discord } from '../../service/discord';
 import { GitHubWorkflow } from '../../model/gitHubWorkflow';
 import { EditorVersionInfo } from '../../model/editorVersionInfo';
 import { RepoVersionInfo } from '../../model/repoVersionInfo';
+import { ReconciliationState, ReconciliationStateData } from '../../model/reconciliationState';
 
 const DOCKERHUB_API = 'https://hub.docker.com/v2/repositories';
-const TAG_PAGE_SIZE = 100;
-const MAX_TAG_PAGES = 50;
-const MAX_RETRIES_PER_CYCLE = 30;
+
+const VERSIONS_PER_CYCLE = 5;
+const MAX_DISPATCHES_PER_CYCLE = 10;
+const MAX_TAG_PAGES_PER_QUERY = 3;
+const DISPATCH_COOLDOWN_MS = 2 * 60 * 60 * 1000;
+const BASE_HUB_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const COOLDOWN_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
 const UBUNTU_PLATFORMS = [
   'base',
   'linux-il2cpp',
@@ -36,10 +42,19 @@ interface DockerImage {
   changeset?: string;
 }
 
-interface MissingImage {
-  image: DockerImage;
-  dispatchedRetry: boolean;
-  error?: string;
+interface CycleSummary {
+  versionsScanned: number;
+  imagesExpected: number;
+  imagesMissing: number;
+  dispatchesAttempted: number;
+  dispatchesSucceeded: number;
+  cooldownSkipped: number;
+  cappedAtLimit: boolean;
+}
+
+interface ReconcilerOptions {
+  now?: () => number;
+  dockerHubToken?: string;
 }
 
 export class DockerImageReconciler {
@@ -47,15 +62,22 @@ export class DockerImageReconciler {
   private repoVersionFull: string;
   private repoVersionMinor: string;
   private repoVersionMajor: string;
-  private missingImages: MissingImage[] = [];
-  private retriesDispatched = 0;
+  private now: () => number;
+  private authHeader: Record<string, string>;
 
-  constructor(gitHubClient: Octokit, repoVersionInfo: RepoVersionInfo) {
+  constructor(
+    gitHubClient: Octokit,
+    repoVersionInfo: RepoVersionInfo,
+    options: ReconcilerOptions = {},
+  ) {
     this.gitHubClient = gitHubClient;
     const { major, minor, patch } = repoVersionInfo;
     this.repoVersionFull = `${major}.${minor}.${patch}`;
     this.repoVersionMinor = `${major}.${minor}`;
     this.repoVersionMajor = String(major);
+    this.now = options.now ?? (() => Date.now());
+    const token = options.dockerHubToken ?? process.env.DOCKERHUB_RECONCILE_TOKEN;
+    this.authHeader = token ? { Authorization: `Bearer ${token}` } : {};
   }
 
   async reconcileEditorImages(versions: EditorVersionInfo[]): Promise<void> {
@@ -63,72 +85,49 @@ export class DockerImageReconciler {
       return;
     }
 
-    const [baseTags, hubTags, editorTags] = await Promise.all([
-      this.fetchExistingTags('unityci/base'),
-      this.fetchExistingTags('unityci/hub'),
-      this.fetchExistingTags('unityci/editor'),
-    ]);
-
-    const expectedImages = this.computeExpectedImages(versions);
-    const tagSetByRepo: Record<string, Set<string>> = {
-      'unityci/base': baseTags,
-      'unityci/hub': hubTags,
-      'unityci/editor': editorTags,
+    const state = await ReconciliationState.load();
+    const summary: CycleSummary = {
+      versionsScanned: 0,
+      imagesExpected: 0,
+      imagesMissing: 0,
+      dispatchesAttempted: 0,
+      dispatchesSucceeded: 0,
+      cooldownSkipped: 0,
+      cappedAtLimit: false,
     };
 
-    for (const image of expectedImages) {
-      if (this.retriesDispatched >= MAX_RETRIES_PER_CYCLE) {
-        break;
-      }
-      const existing = tagSetByRepo[image.repository];
-      if (existing.has(image.tag)) {
-        continue;
-      }
-      const dispatchedRetry = await this.dispatchRetry(image);
-      if (dispatchedRetry) {
-        this.retriesDispatched += 1;
-      }
-      this.missingImages.push({ image, dispatchedRetry });
+    if (this.shouldCheckBaseHub(state)) {
+      await this.processBaseHub(state, summary);
+      state.baseHubCheckedAt = this.now();
     }
 
-    await this.reportResults(expectedImages.length);
-  }
-
-  private async fetchExistingTags(repository: string): Promise<Set<string>> {
-    const tags = new Set<string>();
-    let nextUrl: string | null =
-      `${DOCKERHUB_API}/${repository}/tags?page_size=${TAG_PAGE_SIZE}&name=${this.repoVersionFull}`;
-    let pagesFetched = 0;
-
-    while (nextUrl && pagesFetched < MAX_TAG_PAGES) {
-      try {
-        const response = await fetch(nextUrl, {
-          headers: { 'User-Agent': 'game-ci-versioning-backend/1.0' },
-        });
-        if (!response.ok) {
-          logger.warn(`DockerHub list tags failed for ${repository}: HTTP ${response.status}`);
-          break;
-        }
-        const body = (await response.json()) as {
-          results?: { name: string }[];
-          next?: string | null;
-        };
-        for (const result of body.results ?? []) {
-          tags.add(result.name);
-        }
-        nextUrl = body.next ?? null;
-        pagesFetched += 1;
-      } catch (error) {
-        logger.warn(`DockerHub list tags error for ${repository}`, error);
+    const versionsToScan = this.pickVersionsForCycle(versions, state);
+    for (const version of versionsToScan) {
+      if (summary.dispatchesAttempted >= MAX_DISPATCHES_PER_CYCLE) {
+        summary.cappedAtLimit = true;
         break;
       }
+      await this.processVersion(version, state, summary);
+      summary.versionsScanned += 1;
+      state.cursorVersion = version.version;
     }
 
-    return tags;
+    state.cycleCount += 1;
+    this.pruneCooldownEntries(state);
+    await ReconciliationState.save(state);
+    await this.reportSummary(summary, versions.length);
   }
 
-  private computeExpectedImages(versions: EditorVersionInfo[]): DockerImage[] {
-    const expected: DockerImage[] = [
+  private shouldCheckBaseHub(state: ReconciliationStateData): boolean {
+    if (state.baseHubCheckedAt === null) return true;
+    return this.now() - state.baseHubCheckedAt >= BASE_HUB_CHECK_INTERVAL_MS;
+  }
+
+  private async processBaseHub(
+    state: ReconciliationStateData,
+    summary: CycleSummary,
+  ): Promise<void> {
+    const checks: DockerImage[] = [
       {
         repository: 'unityci/base',
         tag: `ubuntu-${this.repoVersionFull}`,
@@ -155,33 +154,161 @@ export class DockerImageReconciler {
       },
     ];
 
-    for (const version of versions) {
-      const { version: editorVersion, changeSet: changeset } = version;
-      for (const platform of UBUNTU_PLATFORMS) {
-        expected.push({
-          repository: 'unityci/editor',
-          tag: `ubuntu-${editorVersion}-${platform}-${this.repoVersionFull}`,
-          baseOs: 'ubuntu',
-          imageType: 'editor',
-          targetPlatform: platform,
-          editorVersion,
-          changeset,
+    const baseTags = await this.fetchTags('unityci/base', this.repoVersionFull);
+    const hubTags = await this.fetchTags('unityci/hub', this.repoVersionFull);
+    const tagSet: Record<string, Set<string> | null> = {
+      'unityci/base': baseTags,
+      'unityci/hub': hubTags,
+    };
+
+    for (const image of checks) {
+      await this.evaluateExpected(image, tagSet[image.repository], state, summary);
+    }
+  }
+
+  private async processVersion(
+    version: EditorVersionInfo,
+    state: ReconciliationStateData,
+    summary: CycleSummary,
+  ): Promise<void> {
+    const ubuntuExisting = await this.fetchTags('unityci/editor', `ubuntu-${version.version}`);
+    const windowsExisting = await this.fetchTags('unityci/editor', `windows-${version.version}`);
+
+    for (const platform of UBUNTU_PLATFORMS) {
+      const image: DockerImage = {
+        repository: 'unityci/editor',
+        tag: `ubuntu-${version.version}-${platform}-${this.repoVersionFull}`,
+        baseOs: 'ubuntu',
+        imageType: 'editor',
+        targetPlatform: platform,
+        editorVersion: version.version,
+        changeset: version.changeSet,
+      };
+      await this.evaluateExpected(image, ubuntuExisting, state, summary);
+      if (summary.dispatchesAttempted >= MAX_DISPATCHES_PER_CYCLE) return;
+    }
+
+    for (const platform of WINDOWS_PLATFORMS) {
+      const image: DockerImage = {
+        repository: 'unityci/editor',
+        tag: `windows-${version.version}-${platform}-${this.repoVersionFull}`,
+        baseOs: 'windows',
+        imageType: 'editor',
+        targetPlatform: platform,
+        editorVersion: version.version,
+        changeset: version.changeSet,
+      };
+      await this.evaluateExpected(image, windowsExisting, state, summary);
+      if (summary.dispatchesAttempted >= MAX_DISPATCHES_PER_CYCLE) return;
+    }
+  }
+
+  private async evaluateExpected(
+    image: DockerImage,
+    existing: Set<string> | null,
+    state: ReconciliationStateData,
+    summary: CycleSummary,
+  ): Promise<void> {
+    summary.imagesExpected += 1;
+
+    if (existing === null) {
+      logger.debug(`Skipping ${image.tag}: existing-tag fetch failed, assuming present`);
+      return;
+    }
+
+    if (existing.has(image.tag)) {
+      return;
+    }
+
+    summary.imagesMissing += 1;
+    const cooldownKey = `${image.repository}:${image.tag}`;
+    const lastDispatchedAt = state.recentDispatches[cooldownKey];
+    if (lastDispatchedAt && this.now() - lastDispatchedAt < DISPATCH_COOLDOWN_MS) {
+      summary.cooldownSkipped += 1;
+      return;
+    }
+
+    if (summary.dispatchesAttempted >= MAX_DISPATCHES_PER_CYCLE) {
+      summary.cappedAtLimit = true;
+      return;
+    }
+
+    summary.dispatchesAttempted += 1;
+    const dispatched = await this.dispatchRetry(image);
+    if (dispatched) {
+      summary.dispatchesSucceeded += 1;
+      state.recentDispatches[cooldownKey] = this.now();
+    }
+  }
+
+  private pickVersionsForCycle(
+    versions: EditorVersionInfo[],
+    state: ReconciliationStateData,
+  ): EditorVersionInfo[] {
+    if (versions.length === 0) return [];
+    const startIndex = state.cursorVersion
+      ? Math.max(0, versions.findIndex((v) => v.version === state.cursorVersion) + 1)
+      : 0;
+    const effectiveStart = startIndex >= versions.length ? 0 : startIndex;
+    const slice = versions.slice(effectiveStart, effectiveStart + VERSIONS_PER_CYCLE);
+    if (slice.length < VERSIONS_PER_CYCLE && effectiveStart > 0) {
+      const remainder = VERSIONS_PER_CYCLE - slice.length;
+      slice.push(...versions.slice(0, remainder));
+    }
+    return slice;
+  }
+
+  private async fetchTags(repository: string, nameFilter: string): Promise<Set<string> | null> {
+    const tags = new Set<string>();
+    let nextUrl: string | null =
+      `${DOCKERHUB_API}/${repository}/tags?page_size=100&name=${encodeURIComponent(nameFilter)}`;
+    let pagesFetched = 0;
+
+    while (nextUrl && pagesFetched < MAX_TAG_PAGES_PER_QUERY) {
+      try {
+        const response = await fetch(nextUrl, {
+          headers: {
+            'User-Agent': 'game-ci-versioning-backend/1.0',
+            ...this.authHeader,
+          },
         });
-      }
-      for (const platform of WINDOWS_PLATFORMS) {
-        expected.push({
-          repository: 'unityci/editor',
-          tag: `windows-${editorVersion}-${platform}-${this.repoVersionFull}`,
-          baseOs: 'windows',
-          imageType: 'editor',
-          targetPlatform: platform,
-          editorVersion,
-          changeset,
-        });
+
+        if (response.status === 429) {
+          logger.warn(`DockerHub rate-limited for ${repository} (${nameFilter})`);
+          return null;
+        }
+        if (!response.ok) {
+          logger.warn(
+            `DockerHub list tags failed for ${repository} (${nameFilter}): HTTP ${response.status}`,
+          );
+          return null;
+        }
+
+        const body = (await response.json()) as {
+          results?: { name: string }[];
+          next?: string | null;
+        };
+        for (const result of body.results ?? []) {
+          tags.add(result.name);
+        }
+        nextUrl = body.next ?? null;
+        pagesFetched += 1;
+      } catch (error) {
+        logger.warn(`DockerHub list tags error for ${repository} (${nameFilter})`, error);
+        return null;
       }
     }
 
-    return expected;
+    return tags;
+  }
+
+  private pruneCooldownEntries(state: ReconciliationStateData): void {
+    const cutoff = this.now() - COOLDOWN_RETENTION_MS;
+    for (const [key, ts] of Object.entries(state.recentDispatches)) {
+      if (ts < cutoff) {
+        delete state.recentDispatches[key];
+      }
+    }
   }
 
   private async dispatchRetry(image: DockerImage): Promise<boolean> {
@@ -228,23 +355,20 @@ export class DockerImageReconciler {
       : GitHubWorkflow.eventTypes.retryWindowsEditorImage;
   }
 
-  private async reportResults(expectedCount: number): Promise<void> {
-    if (this.missingImages.length === 0) {
+  private async reportSummary(summary: CycleSummary, totalVersions: number): Promise<void> {
+    if (summary.imagesMissing === 0) {
       await Discord.sendDebug(
-        `[DockerImageReconciler] Verified ${expectedCount} expected images, all present`,
+        `[DockerImageReconciler] Scanned ${summary.versionsScanned}/${totalVersions} versions, ` +
+          `${summary.imagesExpected} images verified, all present`,
       );
       return;
     }
 
-    const successful = this.missingImages.filter((m) => m.dispatchedRetry).length;
-    const failed = this.missingImages.length - successful;
-
     await Discord.sendAlert(
-      `DockerHub Reconciliation: ${this.missingImages.length} missing of ${expectedCount} expected; ` +
-        `retried ${successful}, failed ${failed}` +
-        (this.retriesDispatched >= MAX_RETRIES_PER_CYCLE
-          ? ` (capped at ${MAX_RETRIES_PER_CYCLE} retries; remaining will retry next cycle)`
-          : ''),
+      `DockerHub Reconciliation: ${summary.imagesMissing} missing across ` +
+        `${summary.versionsScanned} versions; dispatched ${summary.dispatchesSucceeded}/${summary.dispatchesAttempted}, ` +
+        `${summary.cooldownSkipped} in cooldown` +
+        (summary.cappedAtLimit ? `, capped at ${MAX_DISPATCHES_PER_CYCLE} dispatches/cycle` : ''),
     );
   }
 }

--- a/functions/src/model/reconciliationState.ts
+++ b/functions/src/model/reconciliationState.ts
@@ -1,0 +1,43 @@
+import { admin, db } from '../service/firebase';
+import Timestamp = admin.firestore.Timestamp;
+
+export const RECONCILIATION_COLLECTION = 'reconciliationState';
+export const DOCKER_HUB_DOC = 'dockerHub';
+
+export interface ReconciliationStateData {
+  cursorVersion: string | null;
+  recentDispatches: Record<string, number>;
+  baseHubCheckedAt: number | null;
+  cycleCount: number;
+  updatedAt?: Timestamp;
+}
+
+export class ReconciliationState {
+  static async load(): Promise<ReconciliationStateData> {
+    const snapshot = await db.collection(RECONCILIATION_COLLECTION).doc(DOCKER_HUB_DOC).get();
+
+    if (!snapshot.exists) {
+      return {
+        cursorVersion: null,
+        recentDispatches: {},
+        baseHubCheckedAt: null,
+        cycleCount: 0,
+      };
+    }
+
+    const data = snapshot.data() as Partial<ReconciliationStateData>;
+    return {
+      cursorVersion: data.cursorVersion ?? null,
+      recentDispatches: data.recentDispatches ?? {},
+      baseHubCheckedAt: data.baseHubCheckedAt ?? null,
+      cycleCount: data.cycleCount ?? 0,
+    };
+  }
+
+  static async save(state: ReconciliationStateData): Promise<void> {
+    await db
+      .collection(RECONCILIATION_COLLECTION)
+      .doc(DOCKER_HUB_DOC)
+      .set({ ...state, updatedAt: Timestamp.now() }, { merge: false });
+  }
+}

--- a/functions/test/dockerImageReconciler.test.ts
+++ b/functions/test/dockerImageReconciler.test.ts
@@ -16,14 +16,13 @@ const stateStore: { current: any } = { current: null };
 vi.mock('../src/model/reconciliationState', () => ({
   ReconciliationState: {
     load: vi.fn(async () => {
-      return (
-        stateStore.current ?? {
-          cursorVersion: null,
-          recentDispatches: {},
-          baseHubCheckedAt: null,
-          cycleCount: 0,
-        }
-      );
+      const fallback = {
+        cursorVersion: null,
+        recentDispatches: {},
+        baseHubCheckedAt: null,
+        cycleCount: 0,
+      };
+      return JSON.parse(JSON.stringify(stateStore.current ?? fallback));
     }),
     save: vi.fn(async (next: any) => {
       stateStore.current = JSON.parse(JSON.stringify(next));
@@ -39,6 +38,23 @@ const { ReconciliationState } = await import('../src/model/reconciliationState')
 
 const repoVersionInfo = { major: 3, minor: 2, patch: 2 } as any;
 
+const UBUNTU_PLATFORMS = [
+  'base',
+  'linux-il2cpp',
+  'windows-mono',
+  'mac-mono',
+  'ios',
+  'android',
+  'webgl',
+] as const;
+const WINDOWS_PLATFORMS = [
+  'base',
+  'windows-il2cpp',
+  'universal-windows-platform',
+  'appletv',
+  'android',
+] as const;
+
 const buildVersion = (version: string, changeSet = 'abc123def456') => ({
   version,
   changeSet,
@@ -53,16 +69,28 @@ const tagsResponse = (tags: string[]) => ({
   json: async () => ({ results: tags.map((name) => ({ name })), next: null }),
 });
 
+const allPresentMock = (versionList: string[]) =>
+  fetchMock.mockImplementation(async (url: string) => {
+    const u = String(url);
+    if (u.includes('unityci/base')) {
+      return tagsResponse(['ubuntu-3.2.2', 'windows-3.2.2']);
+    }
+    if (u.includes('unityci/hub')) {
+      return tagsResponse(['ubuntu-3.2.2', 'windows-3.2.2']);
+    }
+    const match = u.match(/name=(ubuntu|windows)-([^&]+)/);
+    if (match) {
+      const os = match[1];
+      const v = decodeURIComponent(match[2]);
+      if (!versionList.includes(v)) return tagsResponse([]);
+      const platforms = os === 'ubuntu' ? UBUNTU_PLATFORMS : WINDOWS_PLATFORMS;
+      return tagsResponse(platforms.map((p) => `${os}-${v}-${p}-3.2.2`));
+    }
+    return tagsResponse([]);
+  });
+
 const createDispatchEvent = vi.fn().mockResolvedValue({ status: 204 });
 const gitHubClient = { repos: { createDispatchEvent } } as any;
-
-const advancingClock = (start: number) => {
-  let t = start;
-  return () => {
-    t += 1;
-    return t;
-  };
-};
 
 beforeEach(() => {
   fetchMock.mockReset();
@@ -85,33 +113,10 @@ describe('DockerImageReconciler (incremental)', () => {
 
   it('reports debug when all expected tags present', async () => {
     const v = '6000.4.10f1';
-    const ubuntuTags = [
-      'base',
-      'linux-il2cpp',
-      'windows-mono',
-      'mac-mono',
-      'ios',
-      'android',
-      'webgl',
-    ].map((p) => `ubuntu-${v}-${p}-3.2.2`);
-    const windowsTags = [
-      'base',
-      'windows-il2cpp',
-      'universal-windows-platform',
-      'appletv',
-      'android',
-    ].map((p) => `windows-${v}-${p}-3.2.2`);
-
-    fetchMock
-      .mockResolvedValueOnce(tagsResponse([`ubuntu-${3.22}`, `ubuntu-3.2.2`]))
-      .mockResolvedValueOnce(tagsResponse([`windows-3.2.2`]))
-      .mockResolvedValueOnce(tagsResponse([`ubuntu-3.2.2`]))
-      .mockResolvedValueOnce(tagsResponse([`windows-3.2.2`]))
-      .mockResolvedValueOnce(tagsResponse(ubuntuTags))
-      .mockResolvedValueOnce(tagsResponse(windowsTags));
+    allPresentMock([v]);
 
     const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
-      now: advancingClock(1_000_000),
+      now: () => 1_000_000,
     });
     await reconciler.reconcileEditorImages([buildVersion(v)]);
 
@@ -120,49 +125,43 @@ describe('DockerImageReconciler (incremental)', () => {
   });
 
   it('advances cursor and resumes from next version on subsequent cycle', async () => {
-    const versions = Array.from({ length: 8 }, (_, i) => buildVersion(`6000.4.${i}f1`));
-    fetchMock.mockResolvedValue(tagsResponse([]));
+    const versions = Array.from({ length: 12 }, (_, i) => buildVersion(`6000.4.${i}f1`));
+    allPresentMock(versions.map((v) => v.version));
 
-    const r1 = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
-      now: advancingClock(1_000_000),
-    });
+    const r1 = new DockerImageReconciler(gitHubClient, repoVersionInfo, { now: () => 1_000_000 });
     await r1.reconcileEditorImages(versions);
-    const stateAfterCycle1 = stateStore.current;
-    expect(stateAfterCycle1.cursorVersion).toBeTruthy();
+    const cursor1 = stateStore.current.cursorVersion;
+    expect(cursor1).toBe('6000.4.4f1');
 
-    const r2 = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
-      now: advancingClock(2_000_000),
-    });
+    const r2 = new DockerImageReconciler(gitHubClient, repoVersionInfo, { now: () => 2_000_000 });
     await r2.reconcileEditorImages(versions);
-    const stateAfterCycle2 = stateStore.current;
-    expect(stateAfterCycle2.cursorVersion).not.toBe(stateAfterCycle1.cursorVersion);
-    expect(stateAfterCycle2.cycleCount).toBe(2);
+    const cursor2 = stateStore.current.cursorVersion;
+    expect(cursor2).toBe('6000.4.9f1');
+    expect(stateStore.current.cycleCount).toBe(2);
   });
 
   it('honors per-tag dispatch cooldown to prevent re-dispatching', async () => {
-    const v = '6000.3.17f1';
-    fetchMock.mockResolvedValue(tagsResponse([]));
+    const v = '6000.4.10f1';
+    const presentUbuntu = UBUNTU_PLATFORMS.filter((p) => p !== 'webgl').map(
+      (p) => `ubuntu-${v}-${p}-3.2.2`,
+    );
+    const presentWindows = WINDOWS_PLATFORMS.map((p) => `windows-${v}-${p}-3.2.2`);
 
-    let t = 1_000_000;
-    const r1 = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
-      now: () => {
-        t += 1;
-        return t;
-      },
+    fetchMock.mockImplementation(async (url: string) => {
+      const u = String(url);
+      if (u.includes('unityci/base')) return tagsResponse(['ubuntu-3.2.2', 'windows-3.2.2']);
+      if (u.includes('unityci/hub')) return tagsResponse(['ubuntu-3.2.2', 'windows-3.2.2']);
+      if (u.includes(`name=ubuntu-${v}`)) return tagsResponse(presentUbuntu);
+      if (u.includes(`name=windows-${v}`)) return tagsResponse(presentWindows);
+      return tagsResponse([]);
     });
+
+    const r1 = new DockerImageReconciler(gitHubClient, repoVersionInfo, { now: () => 1_000_000 });
     await r1.reconcileEditorImages([buildVersion(v)]);
-    const dispatchedFirst = createDispatchEvent.mock.calls.length;
-    expect(dispatchedFirst).toBeGreaterThan(0);
+    expect(createDispatchEvent).toHaveBeenCalledTimes(1);
 
     createDispatchEvent.mockClear();
-    fetchMock.mockClear();
-    fetchMock.mockResolvedValue(tagsResponse([]));
-    const r2 = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
-      now: () => {
-        t += 1;
-        return t;
-      },
-    });
+    const r2 = new DockerImageReconciler(gitHubClient, repoVersionInfo, { now: () => 1_000_500 });
     await r2.reconcileEditorImages([buildVersion(v)]);
     expect(createDispatchEvent).not.toHaveBeenCalled();
   });
@@ -171,7 +170,7 @@ describe('DockerImageReconciler (incremental)', () => {
     fetchMock.mockResolvedValue(tagsResponse([]));
     const versions = Array.from({ length: 5 }, (_, i) => buildVersion(`6000.4.${i}f1`));
     const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
-      now: advancingClock(1_000_000),
+      now: () => 1_000_000,
     });
     await reconciler.reconcileEditorImages(versions);
     expect(createDispatchEvent.mock.calls.length).toBeLessThanOrEqual(10);
@@ -180,14 +179,14 @@ describe('DockerImageReconciler (incremental)', () => {
   it('skips dispatch and does not crash when DockerHub returns 429', async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 429, json: async () => ({}) });
     const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
-      now: advancingClock(1_000_000),
+      now: () => 1_000_000,
     });
     await reconciler.reconcileEditorImages([buildVersion('6000.4.10f1')]);
     expect(createDispatchEvent).not.toHaveBeenCalled();
   });
 
   it('skips base/hub if checked recently', async () => {
-    fetchMock.mockResolvedValue(tagsResponse([]));
+    allPresentMock(['6000.4.10f1']);
     stateStore.current = {
       cursorVersion: null,
       recentDispatches: {},
@@ -209,7 +208,7 @@ describe('DockerImageReconciler (incremental)', () => {
   it('persists cooldown timestamps in state for next cycle', async () => {
     fetchMock.mockResolvedValue(tagsResponse([]));
     const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
-      now: advancingClock(1_000_000),
+      now: () => 1_000_000,
     });
     await reconciler.reconcileEditorImages([buildVersion('6000.4.10f1')]);
     expect(stateStore.current).toBeTruthy();
@@ -217,23 +216,19 @@ describe('DockerImageReconciler (incremental)', () => {
   });
 
   it('wraps cursor around to beginning when reaching end of version list', async () => {
-    fetchMock.mockResolvedValue(tagsResponse([]));
-    const versions = [
-      buildVersion('6000.4.10f1'),
-      buildVersion('6000.3.17f1'),
-      buildVersion('6000.2.5f1'),
-    ];
+    const versions = Array.from({ length: 8 }, (_, i) => buildVersion(`6000.4.${i}f1`));
+    allPresentMock(versions.map((v) => v.version));
     stateStore.current = {
-      cursorVersion: '6000.2.5f1',
+      cursorVersion: '6000.4.7f1',
       recentDispatches: {},
-      baseHubCheckedAt: Date.now(),
+      baseHubCheckedAt: 999_999_999_999,
       cycleCount: 5,
     };
 
     const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
-      now: advancingClock(2_000_000),
+      now: () => 2_000_000,
     });
     await reconciler.reconcileEditorImages(versions);
-    expect(stateStore.current.cursorVersion).not.toBe('6000.2.5f1');
+    expect(stateStore.current.cursorVersion).toBe('6000.4.4f1');
   });
 });

--- a/functions/test/dockerImageReconciler.test.ts
+++ b/functions/test/dockerImageReconciler.test.ts
@@ -12,10 +12,30 @@ vi.mock('../src/service/discord', () => ({
   },
 }));
 
+const stateStore: { current: any } = { current: null };
+vi.mock('../src/model/reconciliationState', () => ({
+  ReconciliationState: {
+    load: vi.fn(async () => {
+      return (
+        stateStore.current ?? {
+          cursorVersion: null,
+          recentDispatches: {},
+          baseHubCheckedAt: null,
+          cycleCount: 0,
+        }
+      );
+    }),
+    save: vi.fn(async (next: any) => {
+      stateStore.current = JSON.parse(JSON.stringify(next));
+    }),
+  },
+}));
+
 const fetchMock = vi.fn();
 vi.stubGlobal('fetch', fetchMock);
 
 const { Discord } = await import('../src/service/discord');
+const { ReconciliationState } = await import('../src/model/reconciliationState');
 
 const repoVersionInfo = { major: 3, minor: 2, patch: 2 } as any;
 
@@ -27,35 +47,45 @@ const buildVersion = (version: string, changeSet = 'abc123def456') => ({
   patch: version.split('.')[2],
 });
 
-const mockTagsResponse = (tags: string[]) => ({
+const tagsResponse = (tags: string[]) => ({
   ok: true,
   status: 200,
   json: async () => ({ results: tags.map((name) => ({ name })), next: null }),
 });
 
-const emptyTagsResponse = () => mockTagsResponse([]);
-
 const createDispatchEvent = vi.fn().mockResolvedValue({ status: 204 });
 const gitHubClient = { repos: { createDispatchEvent } } as any;
+
+const advancingClock = (start: number) => {
+  let t = start;
+  return () => {
+    t += 1;
+    return t;
+  };
+};
 
 beforeEach(() => {
   fetchMock.mockReset();
   createDispatchEvent.mockClear();
   (Discord.sendDebug as any).mockClear();
   (Discord.sendAlert as any).mockClear();
+  (ReconciliationState.load as any).mockClear();
+  (ReconciliationState.save as any).mockClear();
+  stateStore.current = null;
 });
 
-describe('DockerImageReconciler', () => {
+describe('DockerImageReconciler (incremental)', () => {
   it('returns early when no versions to reconcile', async () => {
     const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo);
     await reconciler.reconcileEditorImages([]);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(createDispatchEvent).not.toHaveBeenCalled();
+    expect(ReconciliationState.save).not.toHaveBeenCalled();
   });
 
-  it('reports success when all expected tags exist on DockerHub', async () => {
-    const editorVersion = '6000.4.10f1';
-    const ubuntuPlatforms = [
+  it('reports debug when all expected tags present', async () => {
+    const v = '6000.4.10f1';
+    const ubuntuTags = [
       'base',
       'linux-il2cpp',
       'windows-mono',
@@ -63,99 +93,147 @@ describe('DockerImageReconciler', () => {
       'ios',
       'android',
       'webgl',
-    ];
-    const windowsPlatforms = [
+    ].map((p) => `ubuntu-${v}-${p}-3.2.2`);
+    const windowsTags = [
       'base',
       'windows-il2cpp',
       'universal-windows-platform',
       'appletv',
       'android',
-    ];
-    const editorTags = [
-      ...ubuntuPlatforms.map((p) => `ubuntu-${editorVersion}-${p}-3.2.2`),
-      ...windowsPlatforms.map((p) => `windows-${editorVersion}-${p}-3.2.2`),
-    ];
+    ].map((p) => `windows-${v}-${p}-3.2.2`);
 
     fetchMock
-      .mockResolvedValueOnce(mockTagsResponse(['ubuntu-3.2.2', 'windows-3.2.2']))
-      .mockResolvedValueOnce(mockTagsResponse(['ubuntu-3.2.2', 'windows-3.2.2']))
-      .mockResolvedValueOnce(mockTagsResponse(editorTags));
+      .mockResolvedValueOnce(tagsResponse([`ubuntu-${3.22}`, `ubuntu-3.2.2`]))
+      .mockResolvedValueOnce(tagsResponse([`windows-3.2.2`]))
+      .mockResolvedValueOnce(tagsResponse([`ubuntu-3.2.2`]))
+      .mockResolvedValueOnce(tagsResponse([`windows-3.2.2`]))
+      .mockResolvedValueOnce(tagsResponse(ubuntuTags))
+      .mockResolvedValueOnce(tagsResponse(windowsTags));
 
-    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo);
-    await reconciler.reconcileEditorImages([buildVersion(editorVersion)]);
+    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
+      now: advancingClock(1_000_000),
+    });
+    await reconciler.reconcileEditorImages([buildVersion(v)]);
 
     expect(createDispatchEvent).not.toHaveBeenCalled();
     expect(Discord.sendDebug).toHaveBeenCalled();
-    expect(Discord.sendAlert).not.toHaveBeenCalled();
   });
 
-  it('dispatches retries for missing editor tags across ALL versions, not just recent ones', async () => {
-    const oldVersion = '6000.3.17f1';
-    const newVersion = '6000.4.10f1';
+  it('advances cursor and resumes from next version on subsequent cycle', async () => {
+    const versions = Array.from({ length: 8 }, (_, i) => buildVersion(`6000.4.${i}f1`));
+    fetchMock.mockResolvedValue(tagsResponse([]));
 
-    fetchMock
-      .mockResolvedValueOnce(mockTagsResponse(['ubuntu-3.2.2', 'windows-3.2.2']))
-      .mockResolvedValueOnce(mockTagsResponse(['ubuntu-3.2.2', 'windows-3.2.2']))
-      .mockResolvedValueOnce(
-        mockTagsResponse([`ubuntu-${newVersion}-base-3.2.2`, `ubuntu-${newVersion}-webgl-3.2.2`]),
-      );
+    const r1 = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
+      now: advancingClock(1_000_000),
+    });
+    await r1.reconcileEditorImages(versions);
+    const stateAfterCycle1 = stateStore.current;
+    expect(stateAfterCycle1.cursorVersion).toBeTruthy();
 
-    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo);
-    await reconciler.reconcileEditorImages([buildVersion(newVersion), buildVersion(oldVersion)]);
-
-    const dispatchedTags = createDispatchEvent.mock.calls.map(
-      (call) => (call[0] as any).client_payload,
-    );
-
-    const oldVersionDispatches = dispatchedTags.filter((p) => p.editorVersion === oldVersion);
-    expect(oldVersionDispatches.length).toBeGreaterThan(0);
-    expect(Discord.sendAlert).toHaveBeenCalled();
+    const r2 = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
+      now: advancingClock(2_000_000),
+    });
+    await r2.reconcileEditorImages(versions);
+    const stateAfterCycle2 = stateStore.current;
+    expect(stateAfterCycle2.cursorVersion).not.toBe(stateAfterCycle1.cursorVersion);
+    expect(stateAfterCycle2.cycleCount).toBe(2);
   });
 
-  it('handles DockerHub tag list API failure without crashing', async () => {
-    fetchMock.mockResolvedValue({ ok: false, status: 503, json: async () => ({}) });
+  it('honors per-tag dispatch cooldown to prevent re-dispatching', async () => {
+    const v = '6000.3.17f1';
+    fetchMock.mockResolvedValue(tagsResponse([]));
 
-    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo);
+    let t = 1_000_000;
+    const r1 = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
+      now: () => {
+        t += 1;
+        return t;
+      },
+    });
+    await r1.reconcileEditorImages([buildVersion(v)]);
+    const dispatchedFirst = createDispatchEvent.mock.calls.length;
+    expect(dispatchedFirst).toBeGreaterThan(0);
+
+    createDispatchEvent.mockClear();
+    fetchMock.mockClear();
+    fetchMock.mockResolvedValue(tagsResponse([]));
+    const r2 = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
+      now: () => {
+        t += 1;
+        return t;
+      },
+    });
+    await r2.reconcileEditorImages([buildVersion(v)]);
+    expect(createDispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('caps dispatches per cycle at MAX_DISPATCHES_PER_CYCLE', async () => {
+    fetchMock.mockResolvedValue(tagsResponse([]));
+    const versions = Array.from({ length: 5 }, (_, i) => buildVersion(`6000.4.${i}f1`));
+    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
+      now: advancingClock(1_000_000),
+    });
+    await reconciler.reconcileEditorImages(versions);
+    expect(createDispatchEvent.mock.calls.length).toBeLessThanOrEqual(10);
+  });
+
+  it('skips dispatch and does not crash when DockerHub returns 429', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 429, json: async () => ({}) });
+    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
+      now: advancingClock(1_000_000),
+    });
+    await reconciler.reconcileEditorImages([buildVersion('6000.4.10f1')]);
+    expect(createDispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('skips base/hub if checked recently', async () => {
+    fetchMock.mockResolvedValue(tagsResponse([]));
+    stateStore.current = {
+      cursorVersion: null,
+      recentDispatches: {},
+      baseHubCheckedAt: 1_000_000,
+      cycleCount: 1,
+    };
+
+    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
+      now: () => 1_000_500,
+    });
     await reconciler.reconcileEditorImages([buildVersion('6000.4.10f1')]);
 
-    // When tags can't be fetched, every expected image looks "missing" - retries should still be capped.
-    expect(createDispatchEvent.mock.calls.length).toBeLessThanOrEqual(30);
-  });
-
-  it('paginates through multiple pages of DockerHub tags', async () => {
-    const editorVersion = '6000.4.10f1';
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({
-          results: [{ name: 'ubuntu-3.2.2' }],
-          next: 'https://hub.docker.com/v2/repositories/unityci/base/tags?page=2',
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({ results: [{ name: 'windows-3.2.2' }], next: null }),
-      })
-      .mockResolvedValue(emptyTagsResponse());
-
-    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo);
-    await reconciler.reconcileEditorImages([buildVersion(editorVersion)]);
-
-    const baseRequests = fetchMock.mock.calls.filter((call) =>
-      String(call[0]).includes('unityci/base'),
+    const baseHubCalls = fetchMock.mock.calls.filter(
+      (c) => String(c[0]).includes('unityci/base') || String(c[0]).includes('unityci/hub'),
     );
-    expect(baseRequests.length).toBeGreaterThanOrEqual(2);
+    expect(baseHubCalls.length).toBe(0);
   });
 
-  it('caps dispatched retries per cycle to prevent API overload', async () => {
-    fetchMock.mockResolvedValue(emptyTagsResponse());
+  it('persists cooldown timestamps in state for next cycle', async () => {
+    fetchMock.mockResolvedValue(tagsResponse([]));
+    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
+      now: advancingClock(1_000_000),
+    });
+    await reconciler.reconcileEditorImages([buildVersion('6000.4.10f1')]);
+    expect(stateStore.current).toBeTruthy();
+    expect(Object.keys(stateStore.current.recentDispatches).length).toBeGreaterThan(0);
+  });
 
-    const manyVersions = Array.from({ length: 10 }, (_, i) => buildVersion(`6000.4.${i}f1`));
-    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo);
-    await reconciler.reconcileEditorImages(manyVersions);
+  it('wraps cursor around to beginning when reaching end of version list', async () => {
+    fetchMock.mockResolvedValue(tagsResponse([]));
+    const versions = [
+      buildVersion('6000.4.10f1'),
+      buildVersion('6000.3.17f1'),
+      buildVersion('6000.2.5f1'),
+    ];
+    stateStore.current = {
+      cursorVersion: '6000.2.5f1',
+      recentDispatches: {},
+      baseHubCheckedAt: Date.now(),
+      cycleCount: 5,
+    };
 
-    expect(createDispatchEvent.mock.calls.length).toBeLessThanOrEqual(30);
+    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo, {
+      now: advancingClock(2_000_000),
+    });
+    await reconciler.reconcileEditorImages(versions);
+    expect(stateStore.current.cursorVersion).not.toBe('6000.2.5f1');
   });
 });

--- a/functions/test/dockerImageReconciler.test.ts
+++ b/functions/test/dockerImageReconciler.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DockerImageReconciler } from '../src/logic/buildQueue/dockerImageReconciler';
+
+vi.mock('firebase-functions/v2', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../src/service/discord', () => ({
+  Discord: {
+    sendDebug: vi.fn().mockResolvedValue(undefined),
+    sendAlert: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+const { Discord } = await import('../src/service/discord');
+
+const repoVersionInfo = { major: 3, minor: 2, patch: 2 } as any;
+
+const buildVersion = (version: string, changeSet = 'abc123def456') => ({
+  version,
+  changeSet,
+  major: Number(version.split('.')[0]),
+  minor: Number(version.split('.')[1]),
+  patch: version.split('.')[2],
+});
+
+const mockTagsResponse = (tags: string[]) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ results: tags.map((name) => ({ name })), next: null }),
+});
+
+const emptyTagsResponse = () => mockTagsResponse([]);
+
+const createDispatchEvent = vi.fn().mockResolvedValue({ status: 204 });
+const gitHubClient = { repos: { createDispatchEvent } } as any;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  createDispatchEvent.mockClear();
+  (Discord.sendDebug as any).mockClear();
+  (Discord.sendAlert as any).mockClear();
+});
+
+describe('DockerImageReconciler', () => {
+  it('returns early when no versions to reconcile', async () => {
+    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo);
+    await reconciler.reconcileEditorImages([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(createDispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('reports success when all expected tags exist on DockerHub', async () => {
+    const editorVersion = '6000.4.10f1';
+    const ubuntuPlatforms = [
+      'base',
+      'linux-il2cpp',
+      'windows-mono',
+      'mac-mono',
+      'ios',
+      'android',
+      'webgl',
+    ];
+    const windowsPlatforms = [
+      'base',
+      'windows-il2cpp',
+      'universal-windows-platform',
+      'appletv',
+      'android',
+    ];
+    const editorTags = [
+      ...ubuntuPlatforms.map((p) => `ubuntu-${editorVersion}-${p}-3.2.2`),
+      ...windowsPlatforms.map((p) => `windows-${editorVersion}-${p}-3.2.2`),
+    ];
+
+    fetchMock
+      .mockResolvedValueOnce(mockTagsResponse(['ubuntu-3.2.2', 'windows-3.2.2']))
+      .mockResolvedValueOnce(mockTagsResponse(['ubuntu-3.2.2', 'windows-3.2.2']))
+      .mockResolvedValueOnce(mockTagsResponse(editorTags));
+
+    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo);
+    await reconciler.reconcileEditorImages([buildVersion(editorVersion)]);
+
+    expect(createDispatchEvent).not.toHaveBeenCalled();
+    expect(Discord.sendDebug).toHaveBeenCalled();
+    expect(Discord.sendAlert).not.toHaveBeenCalled();
+  });
+
+  it('dispatches retries for missing editor tags across ALL versions, not just recent ones', async () => {
+    const oldVersion = '6000.3.17f1';
+    const newVersion = '6000.4.10f1';
+
+    fetchMock
+      .mockResolvedValueOnce(mockTagsResponse(['ubuntu-3.2.2', 'windows-3.2.2']))
+      .mockResolvedValueOnce(mockTagsResponse(['ubuntu-3.2.2', 'windows-3.2.2']))
+      .mockResolvedValueOnce(
+        mockTagsResponse([`ubuntu-${newVersion}-base-3.2.2`, `ubuntu-${newVersion}-webgl-3.2.2`]),
+      );
+
+    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo);
+    await reconciler.reconcileEditorImages([buildVersion(newVersion), buildVersion(oldVersion)]);
+
+    const dispatchedTags = createDispatchEvent.mock.calls.map(
+      (call) => (call[0] as any).client_payload,
+    );
+
+    const oldVersionDispatches = dispatchedTags.filter((p) => p.editorVersion === oldVersion);
+    expect(oldVersionDispatches.length).toBeGreaterThan(0);
+    expect(Discord.sendAlert).toHaveBeenCalled();
+  });
+
+  it('handles DockerHub tag list API failure without crashing', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503, json: async () => ({}) });
+
+    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo);
+    await reconciler.reconcileEditorImages([buildVersion('6000.4.10f1')]);
+
+    // When tags can't be fetched, every expected image looks "missing" - retries should still be capped.
+    expect(createDispatchEvent.mock.calls.length).toBeLessThanOrEqual(30);
+  });
+
+  it('paginates through multiple pages of DockerHub tags', async () => {
+    const editorVersion = '6000.4.10f1';
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          results: [{ name: 'ubuntu-3.2.2' }],
+          next: 'https://hub.docker.com/v2/repositories/unityci/base/tags?page=2',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ results: [{ name: 'windows-3.2.2' }], next: null }),
+      })
+      .mockResolvedValue(emptyTagsResponse());
+
+    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo);
+    await reconciler.reconcileEditorImages([buildVersion(editorVersion)]);
+
+    const baseRequests = fetchMock.mock.calls.filter((call) =>
+      String(call[0]).includes('unityci/base'),
+    );
+    expect(baseRequests.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('caps dispatched retries per cycle to prevent API overload', async () => {
+    fetchMock.mockResolvedValue(emptyTagsResponse());
+
+    const manyVersions = Array.from({ length: 10 }, (_, i) => buildVersion(`6000.4.${i}f1`));
+    const reconciler = new DockerImageReconciler(gitHubClient, repoVersionInfo);
+    await reconciler.reconcileEditorImages(manyVersions);
+
+    expect(createDispatchEvent.mock.calls.length).toBeLessThanOrEqual(30);
+  });
+});


### PR DESCRIPTION
## Summary

Rewrites the reconciler to be **incremental, rate-limit aware, and reliable at scale**. Carries persistent state in Firestore so cycles cooperate rather than redoing each other's work.

## Why

The previous design (PR #100) checked only the 5 most-recent versions, so older patches like \`6000.3.17f1-3.2.2\` that released after newer 6000.4.x versions were never reconciled. A naive \"check all versions per cycle\" approach would either blow through DockerHub's 200-req/6h anonymous rate limit or walk unbounded tag lists.

## Design

**Per cycle (every scheduler run):**
1. Load \`reconciliationState/dockerHub\` Firestore doc.
2. If base/hub last checked >6h ago, fetch \`unityci/{base,hub}/tags?name=<repoVersion>\` and verify the four base+hub tags.
3. Pick the next \`VERSIONS_PER_CYCLE=5\` versions starting after the saved cursor; wrap to start of list when end reached.
4. For each picked version, fetch \`unityci/editor/tags?name=ubuntu-<editorVersion>\` and \`name=windows-<editorVersion>\` — small, bounded result sets.
5. For each expected (version × platform × OS) tuple, dispatch a retry only if:
   - tag is missing on DockerHub, AND
   - not in cooldown (last dispatch >2h ago), AND
   - cycle hasn't already hit \`MAX_DISPATCHES_PER_CYCLE=10\`.
6. Record dispatch timestamp in state; advance cursor; persist; prune cooldown entries older than 7d.

## Rate-limit math

| Resource | Per-cycle cost | At 5min cycle | 6h budget | Headroom |
|---|---|---|---|---|
| DockerHub tag list (anon, 200/6h) | ~10 GETs (5 versions × 2 OS, base/hub amortized) | 72 cycles × 10 = 720/6h ❌ | 200 | **Too tight** |
| DockerHub tag list (auth, 5000/6h) | ~10 GETs | 720/6h ✅ | 5000 | 7x headroom |
| GitHub repository_dispatch | ≤10 per cycle | 720/hour cap | ample | OK |

→ When \`DOCKERHUB_RECONCILE_TOKEN\` is set, anonymous limits don't apply. Without it, the scheduler cron frequency should be ≥10 min, OR the 429 handler in this PR keeps things safe (skip cycle, retry next time).

## Safety features

- **Cursor in Firestore** — cycles cooperate, no version is starved.
- **Per-tag 2h cooldown** — same retry never dispatched twice within 2h, even if DockerHub is slow to publish the rebuild.
- **\`MAX_TAG_PAGES_PER_QUERY=3\`** — never walks more than 300 tags per query, regardless of total tag count.
- **429 handling** — returns null (treats as 'assume present') instead of dispatching, avoiding cascading dispatches when DockerHub throttles.
- **Cooldown pruning** — entries older than 7d removed from Firestore doc, keeping document size bounded.
- **\`now\` is injectable** — full clock control in tests.

## What's in this PR

- \`functions/src/model/reconciliationState.ts\` — new Firestore-backed state model.
- \`functions/src/logic/buildQueue/dockerImageReconciler.ts\` — rewritten to incremental approach.
- \`functions/test/dockerImageReconciler.test.ts\` — covers cursor advancement, cooldown, base/hub interval, 429, dispatch cap, persistence.

## Test plan

- [x] \`oxfmt --check\` passes
- [x] \`tsc --noEmit\` passes
- [ ] CI green
- [ ] After merge: confirm cursor advances across cycles in Firestore console
- [ ] After merge: confirm \`6000.3.17f1-3.2.2\` gets dispatched in a future cycle (will reach it within ⌈N/5⌉ cycles)

## Follow-ups (not in this PR)

- Set \`DOCKERHUB_RECONCILE_TOKEN\` secret in Firebase config to lift anon rate limits.
- Tune \`VERSIONS_PER_CYCLE\` once we know real-world cycle latency from production logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)